### PR TITLE
feat: `AttestationPayload` from `SignedAttestation`

### DIFF
--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -158,7 +158,11 @@ pub fn att_data_from_signed_att(
 #[cfg(test)]
 mod tests {
 	use crate::attestation::*;
-	use ethers::signers::{Signer, Wallet};
+	use ethers::{
+		prelude::k256::ecdsa::SigningKey,
+		signers::{Signer, Wallet},
+		types::Bytes,
+	};
 	use secp256k1::{ecdsa::RecoveryId, Message, Secp256k1, SecretKey};
 
 	#[test]
@@ -309,11 +313,8 @@ mod tests {
 		let signed_attestation = SignedAttestation { attestation, signature };
 
 		// Replace with expected address
-		let expected_address = Wallet::from(
-			ethers::core::k256::ecdsa::SigningKey::from_bytes(secret_key_as_bytes.as_ref())
-				.unwrap(),
-		)
-		.address();
+		let expected_address =
+			Wallet::from(SigningKey::from_bytes(secret_key_as_bytes.as_ref()).unwrap()).address();
 
 		assert_eq!(
 			address_from_signed_att(&signed_attestation).unwrap(),
@@ -347,17 +348,14 @@ mod tests {
 
 		let contract_att_data = att_data_from_signed_att(&signed_attestation).unwrap();
 
-		let expected_address = Wallet::from(
-			ethers::core::k256::ecdsa::SigningKey::from_bytes(secret_key_as_bytes.as_ref())
-				.unwrap(),
-		)
-		.address();
+		let expected_address =
+			Wallet::from(SigningKey::from_bytes(secret_key_as_bytes.as_ref()).unwrap()).address();
 		assert_eq!(contract_att_data.0, expected_address);
 
 		let expected_attestation_hash = signed_attestation.attestation.hash().to_bytes();
 		assert_eq!(contract_att_data.1, expected_attestation_hash);
 
-		let expected_payload: ethers::types::Bytes =
+		let expected_payload: Bytes =
 			AttestationPayload::from_signed_attestation(&signed_attestation)
 				.unwrap()
 				.to_bytes()

--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -142,15 +142,15 @@ pub fn att_data_from_signed_att(
 	// Recover the Ethereum address from the signed attestation
 	let address = address_from_signed_att(signed_attestation)?;
 
-	// Calculate the hash of the attestation
-	let attestation_hash = signed_attestation.attestation.hash().to_bytes();
+	// Get the attestation key
+	let key = signed_attestation.attestation.key.to_bytes();
 
 	// Get the payload bytes
 	let payload = AttestationPayload::from_signed_attestation(&signed_attestation)?;
 
 	Ok(ContractAttestationData(
 		address,
-		attestation_hash,
+		key,
 		payload.to_bytes().into(),
 	))
 }
@@ -352,8 +352,8 @@ mod tests {
 			Wallet::from(SigningKey::from_bytes(secret_key_as_bytes.as_ref()).unwrap()).address();
 		assert_eq!(contract_att_data.0, expected_address);
 
-		let expected_attestation_hash = signed_attestation.attestation.hash().to_bytes();
-		assert_eq!(contract_att_data.1, expected_attestation_hash);
+		let expected_key = signed_attestation.attestation.key.to_bytes();
+		assert_eq!(contract_att_data.1, expected_key);
 
 		let expected_payload: Bytes =
 			AttestationPayload::from_signed_attestation(&signed_attestation)

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -26,7 +26,7 @@ pub mod eth;
 pub mod utils;
 
 use att_station::{AttestationCreatedFilter, AttestationStation};
-use attestation::{get_contract_attestation_data, Attestation, AttestationPayload};
+use attestation::{att_data_from_signed_att, Attestation, AttestationPayload};
 use eigen_trust_circuit::dynamic_sets::native::SignedAttestation;
 use error::EigenError;
 use eth::ecdsa_secret_from_mnemonic;
@@ -102,9 +102,8 @@ impl Client {
 		let as_address = as_address_res.map_err(|_| EigenError::ParseError)?;
 		let as_contract = AttestationStation::new(as_address, self.client.clone());
 
-		let tx_call = as_contract.attest(vec![
-			get_contract_attestation_data(&signed_attestation).unwrap()
-		]);
+		let tx_call =
+			as_contract.attest(vec![att_data_from_signed_att(&signed_attestation).unwrap()]);
 		let tx_res = tx_call.send();
 		let tx = tx_res.await.map_err(|_| EigenError::TransactionError)?;
 		let res = tx.await.map_err(|_| EigenError::TransactionError)?;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -43,7 +43,7 @@ use ethers::{
 	providers::{Http, Provider},
 	signers::{coins_bip39::English, MnemonicBuilder},
 };
-use secp256k1::{ecdsa::RecoverableSignature, SECP256K1};
+use secp256k1::{ecdsa::RecoverableSignature, Message, SecretKey, SECP256K1};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -81,7 +81,7 @@ impl Client {
 	/// Submit an attestation to the attestation station
 	pub async fn attest(&self, attestation: Attestation) -> Result<(), EigenError> {
 		let ctx = SECP256K1;
-		let secret_keys: Vec<secp256k1::SecretKey> =
+		let secret_keys: Vec<SecretKey> =
 			ecdsa_secret_from_mnemonic(&self.config.mnemonic, 1).unwrap();
 
 		// Get AttestationFr
@@ -92,7 +92,7 @@ impl Client {
 
 		// Sign attestation
 		let signature: RecoverableSignature = ctx.sign_ecdsa_recoverable(
-			&secp256k1::Message::from_slice(att_hash.to_bytes().as_slice()).unwrap(),
+			&Message::from_slice(att_hash.to_bytes().as_slice()).unwrap(),
 			&secret_keys[0],
 		);
 


### PR DESCRIPTION
# Related Issues

 - Closes #243

# Description

This PR makes it possible to get the `AttestationPayload` data, which is the actual data stored in the Attestation Station contract, from a `SignedAttestation` struct.

Also updates `att_data_from_signed_att` with the correct `val` data.

# Changes

- Remove absolute import paths from the client.
- Implement `address_from_public_key()` in the `eth` module. Adapts `address_from_signed_att()`.
- Implement `from_signed_attestation` for `AttestationPayload`.
- Update `att_data_from_signed_att`.
- Add tests.