### PR TITLE
feat: clippy lint rule to deny redundant clone

### DIFF
--- a/circuit/src/circuit.rs
+++ b/circuit/src/circuit.rs
@@ -344,7 +344,7 @@ impl<
 			)?;
 		}
 
-		let mut s = vec![init_score.clone(); NUM_NEIGHBOURS];
+		let mut s = vec![init_score; NUM_NEIGHBOURS];
 		for _ in 0..NUM_ITER {
 			let mut distributions = Vec::new();
 			for i in 0..NUM_NEIGHBOURS {
@@ -388,7 +388,7 @@ impl<
 			passed_scaled.push(res);
 		}
 
-		let mut sum = zero.clone();
+		let mut sum = zero;
 		for i in 0..NUM_NEIGHBOURS {
 			let add_chipset = AddChipset::new(sum.clone(), passed_s[i].clone());
 			sum = add_chipset.synthesize(
@@ -534,7 +534,7 @@ mod test {
 		let signatures: Vec<Signature> = secret_keys
 			.into_iter()
 			.zip(pub_keys.clone())
-			.zip(messages.clone())
+			.zip(messages)
 			.map(|((sk, pk), msg)| sign(&sk, &pk, msg))
 			.collect();
 
@@ -602,7 +602,7 @@ mod test {
 		let signatures: Vec<Signature> = secret_keys
 			.into_iter()
 			.zip(pub_keys.clone())
-			.zip(messages.clone())
+			.zip(messages)
 			.map(|((sk, pk), msg)| sign(&sk, &pk, msg))
 			.collect();
 
@@ -668,7 +668,7 @@ mod test {
 		let signatures: Vec<Signature> = secret_keys
 			.into_iter()
 			.zip(pub_keys.clone())
-			.zip(messages.clone())
+			.zip(messages)
 			.map(|((sk, pk), msg)| sign(&sk, &pk, msg))
 			.collect();
 
@@ -684,7 +684,7 @@ mod test {
 		let deployment_code = gen_evm_verifier(&params, pk.get_vk(), vec![NUM_NEIGHBOURS]);
 		dbg!(deployment_code.len());
 
-		let proof = gen_proof(&params, &pk, et.clone(), vec![res.clone()]);
+		let proof = gen_proof(&params, &pk, et, vec![res.clone()]);
 		evm_verify(deployment_code, vec![res], proof);
 	}
 }

--- a/circuit/src/dynamic_sets/mod.rs
+++ b/circuit/src/dynamic_sets/mod.rs
@@ -649,7 +649,7 @@ impl<const NUM_NEIGHBOURS: usize, const NUM_ITER: usize, const INITIAL_SCORE: u1
 		};
 
 		// Compute the EigenTrust scores
-		let mut s = vec![init_score.clone(); NUM_NEIGHBOURS];
+		let mut s = vec![init_score; NUM_NEIGHBOURS];
 		for _ in 0..NUM_ITER {
 			let mut sop = Vec::new();
 			for i in 0..NUM_NEIGHBOURS {
@@ -698,7 +698,7 @@ impl<const NUM_NEIGHBOURS: usize, const NUM_ITER: usize, const INITIAL_SCORE: u1
 		)?;
 
 		// Constrain the total reputation in the set
-		let mut sum = zero.clone();
+		let mut sum = zero;
 		for i in 0..NUM_NEIGHBOURS {
 			let add_chipset = AddChipset::new(sum.clone(), passed_s[i].clone());
 			sum = add_chipset.synthesize(
@@ -911,7 +911,7 @@ mod test {
 		let deployment_code = gen_evm_verifier(&params, pk.get_vk(), vec![NUM_NEIGHBOURS]);
 		dbg!(deployment_code.len());
 
-		let proof = gen_proof(&params, &pk, et.clone(), vec![res.clone()]);
+		let proof = gen_proof(&params, &pk, et, vec![res.clone()]);
 		evm_verify(deployment_code, vec![res], proof);
 	}
 }

--- a/circuit/src/dynamic_sets/native.rs
+++ b/circuit/src/dynamic_sets/native.rs
@@ -926,7 +926,7 @@ mod test {
 
 		let sks: Vec<SecretKey> =
 			(0..NUM_NEIGHBOURS).into_iter().map(|__| SecretKey::random(rng)).collect();
-		let pks: Vec<PublicKey> = sks.clone().iter().map(|s| s.public()).collect();
+		let pks: Vec<PublicKey> = sks.iter().map(|s| s.public()).collect();
 
 		// Add the publicKey to the set
 		pks.iter().for_each(|pk| set.add_member(*pk));

--- a/circuit/src/ecc/mod.rs
+++ b/circuit/src/ecc/mod.rs
@@ -180,7 +180,7 @@ where
 		)?;
 
 		// r_x = m_squared_minus_p_x.result.sub(&q.x)
-		let r_x_chip = IntegerSubChip::new(m_squared_minus_p_x, q_x_reduced.clone());
+		let r_x_chip = IntegerSubChip::new(m_squared_minus_p_x, q_x_reduced);
 		let r_x = r_x_chip.synthesize(
 			&common,
 			&config.integer_sub_selector,
@@ -285,7 +285,7 @@ where
 		)?;
 
 		// Reduce p_y
-		let p_y = IntegerReduceChip::new(self.p.y.clone());
+		let p_y = IntegerReduceChip::new(self.p.y);
 		let p_y_reduced = p_y.synthesize(
 			&common,
 			&config.integer_reduce_selector,
@@ -671,13 +671,13 @@ where
 			let selected_x_integer =
 				AssignedInteger::new(self.p.x.integer.clone(), selected_x.map(|x| x.unwrap()));
 			let selected_y_integer =
-				AssignedInteger::new(self.p.y.integer.clone(), selected_y.map(|x| x.unwrap()));
+				AssignedInteger::new(self.p.y.integer, selected_y.map(|x| x.unwrap()));
 			AssignedPoint::new(selected_x_integer, selected_y_integer)
 		} else {
 			let selected_x_integer =
 				AssignedInteger::new(self.q.x.integer.clone(), selected_x.map(|x| x.unwrap()));
 			let selected_y_integer =
-				AssignedInteger::new(self.q.y.integer.clone(), selected_y.map(|x| x.unwrap()));
+				AssignedInteger::new(self.q.y.integer, selected_y.map(|x| x.unwrap()));
 			AssignedPoint::new(selected_x_integer, selected_y_integer)
 		};
 
@@ -1089,8 +1089,8 @@ mod test {
 		let a = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a_big);
 		let b = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(b_big);
 		let c = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(c_big);
-		let p_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a.clone(), b.clone());
-		let q_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(b.clone(), c.clone());
+		let p_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a, b.clone());
+		let q_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(b, c);
 
 		let res = p_point.add(&q_point);
 		let test_chip = EccAddTestCircuit::new(p_point, q_point);
@@ -1159,7 +1159,7 @@ mod test {
 		let b_big = BigUint::from_str("65464575675").unwrap();
 		let a = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a_big);
 		let b = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(b_big);
-		let p_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a.clone(), b.clone());
+		let p_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a, b);
 
 		let res = p_point.double();
 		let test_chip = EccDoubleTestCircuit::new(p_point);
@@ -1237,8 +1237,8 @@ mod test {
 		let a = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a_big);
 		let b = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(b_big);
 		let c = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(c_big);
-		let p_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a.clone(), c.clone());
-		let q_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(b.clone(), c.clone());
+		let p_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a, c.clone());
+		let q_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(b, c);
 
 		let res = p_point.ladder(&q_point);
 		let test_chip = EccLadderTestCircuit::new(p_point, q_point);
@@ -1330,7 +1330,7 @@ mod test {
 		let b_big = BigUint::from_str("6546457298123794342352534089237495253453455675").unwrap();
 		let a = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a_big);
 		let b = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(b_big);
-		let p_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a.clone(), b.clone());
+		let p_point = EcPoint::<W, N, NUM_LIMBS, NUM_BITS, P>::new(a, b);
 
 		let res = p_point.mul_scalar(scalar);
 		let test_chip = EccMulTestCircuit::new(p_point, scalar);

--- a/circuit/src/ecc/native.rs
+++ b/circuit/src/ecc/native.rs
@@ -156,7 +156,7 @@ where
 		bits = bits[..N::NUM_BITS as usize].to_vec();
 		bits.reverse();
 
-		let table = [aux_init.clone(), exp.clone().add(&aux_init)];
+		let table = [aux_init.clone(), exp.add(&aux_init)];
 		let mut acc = Self::select(bits[0], table.clone());
 
 		// To avoid P_0 == P_1

--- a/circuit/src/eddsa/mod.rs
+++ b/circuit/src/eddsa/mod.rs
@@ -132,7 +132,7 @@ where
 		)?;
 
 		// Cr = R + H(R || PK || M) * PK
-		let big_r_point = AssignedPoint::new(self.big_r_x.clone(), self.big_r_y.clone(), one);
+		let big_r_point = AssignedPoint::new(self.big_r_x.clone(), self.big_r_y, one);
 		let cr_chip = PointAddChip::<F, P>::new(big_r_point, pk_h);
 		let cr = cr_chip.synthesize(
 			common,

--- a/circuit/src/edwards/mod.rs
+++ b/circuit/src/edwards/mod.rs
@@ -92,19 +92,19 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for PointAddChip<F, P> {
 			let r_z_next_exp = v_cells.query_advice(common.advice[2], Rotation::next());
 
 			let (r_x3, r_y3, r_z3) = P::add_exp(
-				r_x_exp.clone(),
-				r_y_exp.clone(),
-				r_z_exp.clone(),
-				e_x_exp.clone(),
-				e_y_exp.clone(),
-				e_z_exp.clone(),
+				r_x_exp,
+				r_y_exp,
+				r_z_exp,
+				e_x_exp,
+				e_y_exp,
+				e_z_exp,
 			);
 
 			vec![
 				// Ensure the point addition of `r` and `e` is properly calculated.
 				s_exp.clone() * (r_x_next_exp - r_x3),
 				s_exp.clone() * (r_y_next_exp - r_y3),
-				s_exp.clone() * (r_z_next_exp - r_z3),
+				s_exp * (r_z_next_exp - r_z3),
 			]
 		});
 
@@ -284,7 +284,7 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for ScalarMulChip<F, P> {
 			let selected_r_y =
 				bit_exp.clone() * (r_y3 - r_y_exp.clone()) - (r_y_next_exp - r_y_exp);
 			let selected_r_z =
-				bit_exp.clone() * (r_z3 - r_z_exp.clone()) - (r_z_next_exp - r_z_exp);
+				bit_exp * (r_z3 - r_z_exp.clone()) - (r_z_next_exp - r_z_exp);
 
 			vec![
 				// Ensure the point addition of `r` and `e` is properly calculated.

--- a/circuit/src/edwards/mod.rs
+++ b/circuit/src/edwards/mod.rs
@@ -91,14 +91,8 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for PointAddChip<F, P> {
 			let r_y_next_exp = v_cells.query_advice(common.advice[1], Rotation::next());
 			let r_z_next_exp = v_cells.query_advice(common.advice[2], Rotation::next());
 
-			let (r_x3, r_y3, r_z3) = P::add_exp(
-				r_x_exp,
-				r_y_exp,
-				r_z_exp,
-				e_x_exp,
-				e_y_exp,
-				e_z_exp,
-			);
+			let (r_x3, r_y3, r_z3) =
+				P::add_exp(r_x_exp, r_y_exp, r_z_exp, e_x_exp, e_y_exp, e_z_exp);
 
 			vec![
 				// Ensure the point addition of `r` and `e` is properly calculated.
@@ -283,8 +277,7 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for ScalarMulChip<F, P> {
 				bit_exp.clone() * (r_x3 - r_x_exp.clone()) - (r_x_next_exp - r_x_exp);
 			let selected_r_y =
 				bit_exp.clone() * (r_y3 - r_y_exp.clone()) - (r_y_next_exp - r_y_exp);
-			let selected_r_z =
-				bit_exp * (r_z3 - r_z_exp.clone()) - (r_z_next_exp - r_z_exp);
+			let selected_r_z = bit_exp * (r_z3 - r_z_exp.clone()) - (r_z_next_exp - r_z_exp);
 
 			vec![
 				// Ensure the point addition of `r` and `e` is properly calculated.

--- a/circuit/src/edwards/params.rs
+++ b/circuit/src/edwards/params.rs
@@ -118,7 +118,7 @@ impl EdwardsParams<Fr> for BabyJubJub {
 		let const_d = Self::d();
 		let const_a = Self::a();
 		// A = Z1*Z2
-		let r_a = r_z.clone() * e_z.clone();
+		let r_a = r_z * e_z;
 		// B = A^2
 		let r_b = r_a.clone().square();
 		// C = X1*X2
@@ -134,7 +134,7 @@ impl EdwardsParams<Fr> for BabyJubJub {
 		// X3 = A*F*((X1+Y1)*(X2+Y2)-C-D)
 		let r_x3 = r_a.clone()
 			* r_f.clone()
-			* ((r_x.clone() + r_y.clone()) * (e_x.clone() + e_y.clone())
+			* ((r_x + r_y) * (e_x + e_y)
 				- r_c.clone() - r_d.clone());
 		// Y3 = A*G*(D-a*C)
 		let r_y3 = r_a * r_g.clone() * (r_d - r_c * const_a.clone());

--- a/circuit/src/edwards/params.rs
+++ b/circuit/src/edwards/params.rs
@@ -132,10 +132,8 @@ impl EdwardsParams<Fr> for BabyJubJub {
 		// G = B+E
 		let r_g = r_b + r_e;
 		// X3 = A*F*((X1+Y1)*(X2+Y2)-C-D)
-		let r_x3 = r_a.clone()
-			* r_f.clone()
-			* ((r_x + r_y) * (e_x + e_y)
-				- r_c.clone() - r_d.clone());
+		let r_x3 =
+			r_a.clone() * r_f.clone() * ((r_x + r_y) * (e_x + e_y) - r_c.clone() - r_d.clone());
 		// Y3 = A*G*(D-a*C)
 		let r_y3 = r_a * r_g.clone() * (r_d - r_c * const_a.clone());
 		// Z3 = F*G

--- a/circuit/src/gadgets/bits2num.rs
+++ b/circuit/src/gadgets/bits2num.rs
@@ -104,7 +104,7 @@ impl<F: FieldExt> Chip<F> for Bits2NumChip<F> {
 					e2 = ctx.assign_advice(common.advice[1], next_e2)?;
 					lc1 = ctx.assign_advice(common.advice[2], next_lc1)?;
 				}
-				ctx.constrain_equal(self.value.clone(), lc1.clone())?;
+				ctx.constrain_equal(self.value.clone(), lc1)?;
 
 				Ok(bits)
 			},

--- a/circuit/src/gadgets/lt_eq_lookup.rs
+++ b/circuit/src/gadgets/lt_eq_lookup.rs
@@ -115,7 +115,7 @@ impl<F: FieldExt> MockChipset<F> for LessEqualChipset<F> {
 			layouter.namespace(|| "x range check"),
 		)?;
 
-		let lookup_range_check_chipset = RangeChipset::<F, K, N, S>::new(self.y.clone());
+		let lookup_range_check_chipset = RangeChipset::<F, K, N, S>::new(self.y);
 		let y = lookup_range_check_chipset.synthesize(
 			mock_common,
 			&config.lookup_range_check,

--- a/circuit/src/gadgets/main.rs
+++ b/circuit/src/gadgets/main.rs
@@ -561,15 +561,12 @@ impl<F: FieldExt> Chipset<F> for SelectChipset<F> {
 		let res = layouter.assign_region(
 			|| "assign values",
 			|region| {
-				let res = self.x.value().zip(self.y.value()).zip(self.bit.value()).map(
-					|((x, y), bit)| {
-						if *bit == F::ONE {
-							*x
-						} else {
-							*y
-						}
-					},
-				);
+				let res = self
+					.x
+					.value()
+					.zip(self.y.value())
+					.zip(self.bit.value())
+					.map(|((x, y), bit)| if *bit == F::ONE { *x } else { *y });
 				let mut ctx = RegionCtx::new(region, 0);
 				let res = ctx.assign_advice(common.advice[0], res)?;
 				Ok(res)

--- a/circuit/src/gadgets/main.rs
+++ b/circuit/src/gadgets/main.rs
@@ -311,7 +311,7 @@ impl<F: FieldExt> Chipset<F> for IsBoolChipset<F> {
 		)?;
 
 		// [a, b, c, d, e]
-		let advices = [self.x.clone(), zero.clone(), self.x.clone(), self.x.clone(), zero];
+		let advices = [self.x.clone(), zero.clone(), self.x.clone(), self.x, zero];
 		// [s_a, s_b, s_c, s_d, s_e, s_mul_ab, s_mul_cd, s_constant]
 		let fixed_add = [F::ONE, F::ZERO, F::ZERO, F::ZERO, F::ZERO];
 		let fixed_mul = [F::ZERO, -F::ONE, F::ZERO];
@@ -446,7 +446,7 @@ impl<F: FieldExt> Chipset<F> for InverseChipset<F> {
 		// | A | B     | C |
 		// | - | ----- | - |
 		// | r | x_inv | r |
-		let advices = [r.clone(), x_inv.clone(), r, zero.clone(), zero.clone()];
+		let advices = [r.clone(), x_inv.clone(), r, zero.clone(), zero];
 		let fixed_add = [F::ZERO, F::ZERO, -F::ONE, F::ZERO, F::ZERO];
 		let fixed_mul = [F::ONE, F::ZERO, F::ZERO];
 		let main_chip = MainChip::new(advices, fixed_add, fixed_mul);

--- a/circuit/src/integer/native.rs
+++ b/circuit/src/integer/native.rs
@@ -372,7 +372,7 @@ mod test {
 			a_big.clone(),
 			a_big.clone(),
 			a_big.clone(),
-			a_big.clone(),
+			a_big,
 		];
 		let carry = Integer::<Fq, Fr, 4, 68, Bn256_4_68>::new(BigUint::one());
 		let mut acc = carry.mul(&carry);
@@ -407,7 +407,7 @@ mod test {
 			a_big.clone(),
 			a_big.clone(),
 			a_big.clone(),
-			a_big.clone(),
+			a_big,
 		];
 		let carry = Integer::<Fq, Fr, 4, 68, Bn256_4_68>::new(BigUint::one());
 		let mut acc = carry.mul(&carry);
@@ -486,7 +486,7 @@ mod test {
 			a_big.clone(),
 			a_big.clone(),
 			a_big.clone(),
-			a_big.clone(),
+			a_big,
 		];
 		let carry = Integer::<Fq, Fr, 4, 68, Bn256_4_68>::new(BigUint::zero());
 		let mut acc = carry.add(&carry);
@@ -521,7 +521,7 @@ mod test {
 			a_big.clone(),
 			a_big.clone(),
 			a_big.clone(),
-			a_big.clone(),
+			a_big,
 		];
 		let carry = Integer::<Fq, Fr, 4, 68, Bn256_4_68>::new(BigUint::one());
 		let mut acc = carry.mul(&carry);
@@ -556,7 +556,7 @@ mod test {
 		));
 		assert_eq!(
 			(c.result.value() + b_big).mod_floor(&Bn256_4_68::wrong_modulus()),
-			a_big.clone()
+			a_big
 		);
 	}
 
@@ -575,7 +575,7 @@ mod test {
 		));
 		assert_eq!(
 			(c.result.value() + b_big).mod_floor(&Bn256_4_68::wrong_modulus()),
-			a_big.clone()
+			a_big
 		);
 	}
 

--- a/circuit/src/lib.rs
+++ b/circuit/src/lib.rs
@@ -1,13 +1,29 @@
 //! The module for the main EigenTrust circuit.
 
+// Rustc
+#![warn(trivial_casts)]
+#![deny(
+	absolute_paths_not_starting_with_crate, deprecated, future_incompatible, missing_docs,
+	nonstandard_style, unreachable_code, unreachable_patterns
+)]
+#![forbid(unsafe_code)]
+// Clippy
 #![allow(clippy::tabs_in_doc_comments)]
 #![deny(
-	future_incompatible, nonstandard_style, missing_docs, deprecated, unreachable_code,
-	unreachable_patterns, absolute_paths_not_starting_with_crate, unsafe_code, clippy::panic,
-	clippy::unnecessary_cast, clippy::cast_lossless, clippy::cast_possible_wrap
+	// Complexity
+	clippy::unnecessary_cast,
+	// clippy::needless_question_mark,
+	// Pedantic
+	clippy::cast_lossless,
+	clippy::cast_possible_wrap,
+	// Perf
+	// clippy::redundant_clone,
+	// Restriction
+	clippy::panic,
+	// Style
+	// clippy::let_and_return,
+	// clippy::needless_borrow
 )]
-#![warn(trivial_casts)]
-#![forbid(unsafe_code)]
 
 use crate::circuit::{PoseidonNativeHasher, PoseidonNativeSponge};
 use eddsa::native::PublicKey;

--- a/circuit/src/lib.rs
+++ b/circuit/src/lib.rs
@@ -17,7 +17,7 @@
 	clippy::cast_lossless,
 	clippy::cast_possible_wrap,
 	// Perf
-	// clippy::redundant_clone,
+	clippy::redundant_clone,
 	// Restriction
 	clippy::panic,
 	// Style

--- a/circuit/src/main.rs
+++ b/circuit/src/main.rs
@@ -75,7 +75,7 @@ pub fn generate_et_verifier() {
 				Scalar::zero(),
 			];
 			let poseidon = PoseidonNativeHasher::new(m_inputs);
-			
+
 			poseidon.permute()[0]
 		})
 		.collect();

--- a/circuit/src/verifier/aggregator.rs
+++ b/circuit/src/verifier/aggregator.rs
@@ -248,7 +248,7 @@ impl Circuit<Fr> for Aggregator {
 		let poseidon = PoseidonConfig::new(full_round_selector, partial_round_selector);
 
 		let absorb_selector = AbsorbChip::<Fr, WIDTH>::configure(&common, meta);
-		let poseidon_sponge = PoseidonSpongeConfig::new(poseidon.clone(), absorb_selector);
+		let poseidon_sponge = PoseidonSpongeConfig::new(poseidon, absorb_selector);
 
 		let bits2num = Bits2NumChip::configure(&common, meta);
 
@@ -460,7 +460,7 @@ mod test {
 			let poseidon = PoseidonConfig::new(full_round_selector, partial_round_selector);
 
 			let absorb_selector = AbsorbChip::<Scalar, WIDTH>::configure(&common, meta);
-			let poseidon_sponge = PoseidonSpongeConfig::new(poseidon.clone(), absorb_selector);
+			let poseidon_sponge = PoseidonSpongeConfig::new(poseidon, absorb_selector);
 
 			let bits2num = Bits2NumChip::configure(&common, meta);
 
@@ -580,11 +580,11 @@ mod test {
 		let instances_1: Vec<Vec<Fr>> = vec![vec![Fr::one()]];
 		let instances_2: Vec<Vec<Fr>> = vec![vec![Fr::one()]];
 
-		let snark_1 = Snark::new(&params.clone(), random_circuit_1, instances_1, rng);
-		let snark_2 = Snark::new(&params.clone(), random_circuit_2, instances_2, rng);
+		let snark_1 = Snark::new(&params, random_circuit_1, instances_1, rng);
+		let snark_2 = Snark::new(&params, random_circuit_2, instances_2, rng);
 
 		let snarks = vec![snark_1, snark_2];
-		let aggregator = Aggregator::new(&params, snarks.clone());
+		let aggregator = Aggregator::new(&params, snarks);
 
 		let circuit = TestCircuit::new(aggregator.clone());
 		let prover = MockProver::run(k, &circuit, vec![aggregator.instances]).unwrap();

--- a/circuit/src/verifier/loader/mod.rs
+++ b/circuit/src/verifier/loader/mod.rs
@@ -708,12 +708,8 @@ where
 				let auxes = base.loader.auxes.clone();
 				let (aux_init, aux_fin) = auxes;
 				let mut layouter = base.loader.layouter.lock().unwrap();
-				let chip = EccMulChipset::new(
-					base.inner.clone(),
-					scalar.inner.clone(),
-					aux_init,
-					aux_fin,
-				);
+				let chip =
+					EccMulChipset::new(base.inner.clone(), scalar.inner.clone(), aux_init, aux_fin);
 				let mul = chip
 					.synthesize(
 						&config.common,

--- a/circuit/src/verifier/loader/mod.rs
+++ b/circuit/src/verifier/loader/mod.rs
@@ -711,8 +711,8 @@ where
 				let chip = EccMulChipset::new(
 					base.inner.clone(),
 					scalar.inner.clone(),
-					aux_init.clone(),
-					aux_fin.clone(),
+					aux_init,
+					aux_fin,
 				);
 				let mul = chip
 					.synthesize(
@@ -721,12 +721,12 @@ where
 						layouter.namespace(|| "ecc_mul"),
 					)
 					.unwrap();
-				Halo2LEcPoint::new(mul, config.clone())
+				Halo2LEcPoint::new(mul, config)
 			})
 			.reduce(|acc, value| {
 				let config = value.loader.clone();
 				let mut layouter = value.loader.layouter.lock().unwrap();
-				let chip = EccAddChipset::new(acc.inner.clone(), value.inner.clone());
+				let chip = EccAddChipset::new(acc.inner, value.inner.clone());
 				let add = chip
 					.synthesize(
 						&config.common,
@@ -734,7 +734,7 @@ where
 						layouter.namespace(|| "ecc_add"),
 					)
 					.unwrap();
-				Halo2LEcPoint::new(add, config.clone())
+				Halo2LEcPoint::new(add, config)
 			})
 			.unwrap();
 		point
@@ -827,7 +827,7 @@ mod test {
 			let poseidon = PoseidonConfig::new(full_round_selector, partial_round_selector);
 
 			let absorb_selector = AbsorbChip::<Scalar, WIDTH>::configure(&common, meta);
-			let poseidon_sponge = PoseidonSpongeConfig::new(poseidon.clone(), absorb_selector);
+			let poseidon_sponge = PoseidonSpongeConfig::new(poseidon, absorb_selector);
 
 			let bits2num = Bits2NumChip::configure(&common, meta);
 

--- a/circuit/src/verifier/loader/native.rs
+++ b/circuit/src/verifier/loader/native.rs
@@ -97,7 +97,7 @@ where
 	/// Performs the `+` operation.
 	fn add(self, rhs: &'a LScalar<C, P>) -> Self::Output {
 		let res = self.inner + rhs.inner;
-		Self { inner: res, loader: self.loader.clone() }
+		Self { inner: res, loader: self.loader }
 	}
 }
 
@@ -152,7 +152,7 @@ where
 	/// Performs the `*` operation.
 	fn mul(self, rhs: &'a LScalar<C, P>) -> Self::Output {
 		let res = self.inner * rhs.inner;
-		Self { inner: res, loader: self.loader.clone() }
+		Self { inner: res, loader: self.loader }
 	}
 }
 
@@ -207,7 +207,7 @@ where
 	/// Performs the `-` operation.
 	fn sub(self, rhs: &'a LScalar<C, P>) -> Self::Output {
 		let res = self.inner - rhs.inner;
-		Self { inner: res, loader: self.loader.clone() }
+		Self { inner: res, loader: self.loader }
 	}
 }
 
@@ -262,7 +262,7 @@ where
 	/// Performs the unary `-` operation.
 	fn neg(self) -> Self::Output {
 		let res = C::Scalar::neg(self.inner.clone());
-		Self { inner: res, loader: self.loader.clone() }
+		Self { inner: res, loader: self.loader }
 	}
 }
 

--- a/circuit/src/verifier/mod.rs
+++ b/circuit/src/verifier/mod.rs
@@ -319,7 +319,7 @@ mod test {
 		dbg!(deployment_code.len());
 
 		let pub_ins = vec![sum; VERTICAL_SIZE];
-		let proof = gen_proof(&params, &pk, circuit.clone(), vec![pub_ins.clone()]);
-		evm_verify(deployment_code, vec![pub_ins.clone()], proof.clone());
+		let proof = gen_proof(&params, &pk, circuit, vec![pub_ins.clone()]);
+		evm_verify(deployment_code, vec![pub_ins], proof);
 	}
 }

--- a/circuit/src/verifier/transcript/mod.rs
+++ b/circuit/src/verifier/transcript/mod.rs
@@ -506,14 +506,10 @@ mod test {
 				)
 				.unwrap();
 
-			let assigned_integer_x = AssignedInteger::<_, _, NUM_LIMBS, NUM_BITS, P>::new(
-				x,
-				assigned_coordinates.0,
-			);
-			let assigned_integer_y = AssignedInteger::<_, _, NUM_LIMBS, NUM_BITS, P>::new(
-				y,
-				assigned_coordinates.1,
-			);
+			let assigned_integer_x =
+				AssignedInteger::<_, _, NUM_LIMBS, NUM_BITS, P>::new(x, assigned_coordinates.0);
+			let assigned_integer_y =
+				AssignedInteger::<_, _, NUM_LIMBS, NUM_BITS, P>::new(y, assigned_coordinates.1);
 
 			let assigned_point = AssignedPoint::<_, _, NUM_LIMBS, NUM_BITS, P>::new(
 				assigned_integer_x, assigned_integer_y,

--- a/circuit/src/verifier/transcript/mod.rs
+++ b/circuit/src/verifier/transcript/mod.rs
@@ -353,7 +353,7 @@ mod test {
 			let poseidon = PoseidonConfig::new(full_round_selector, partial_round_selector);
 
 			let absorb_selector = AbsorbChip::<Scalar, WIDTH>::configure(&common, meta);
-			let poseidon_sponge = PoseidonSpongeConfig::new(poseidon.clone(), absorb_selector);
+			let poseidon_sponge = PoseidonSpongeConfig::new(poseidon, absorb_selector);
 
 			let bits2num = Bits2NumChip::configure(&common, meta);
 
@@ -415,7 +415,7 @@ mod test {
 			let res = poseidon_read.squeeze_challenge();
 
 			let mut lb = layouter_rc.lock().unwrap();
-			lb.constrain_instance(res.inner.clone().cell(), config.common.instance, 0)?;
+			lb.constrain_instance(res.inner.cell(), config.common.instance, 0)?;
 
 			Ok(())
 		}
@@ -507,11 +507,11 @@ mod test {
 				.unwrap();
 
 			let assigned_integer_x = AssignedInteger::<_, _, NUM_LIMBS, NUM_BITS, P>::new(
-				x.clone(),
+				x,
 				assigned_coordinates.0,
 			);
 			let assigned_integer_y = AssignedInteger::<_, _, NUM_LIMBS, NUM_BITS, P>::new(
-				y.clone(),
+				y,
 				assigned_coordinates.1,
 			);
 
@@ -531,7 +531,7 @@ mod test {
 				&config.poseidon_sponge,
 				lb.namespace(|| "squeeze"),
 			)?;
-			lb.constrain_instance(res.clone().cell(), config.common.instance, 0)?;
+			lb.constrain_instance(res.cell(), config.common.instance, 0)?;
 			Ok(())
 		}
 	}
@@ -612,7 +612,7 @@ mod test {
 				&config.poseidon_sponge,
 				lb.namespace(|| "squeeze"),
 			)?;
-			lb.constrain_instance(res.clone().cell(), config.common.instance, 0)?;
+			lb.constrain_instance(res.cell(), config.common.instance, 0)?;
 
 			Ok(())
 		}
@@ -675,7 +675,7 @@ mod test {
 			let res = poseidon_read.read_scalar().unwrap();
 
 			let mut lb = layouter_rc.lock().unwrap();
-			lb.constrain_instance(res.inner.clone().cell(), config.common.instance, 0)?;
+			lb.constrain_instance(res.inner.cell(), config.common.instance, 0)?;
 
 			Ok(())
 		}
@@ -835,7 +835,7 @@ mod test {
 
 			let res = poseidon_read.read_scalar().unwrap();
 			let mut lb = layouter_rc.lock().unwrap();
-			lb.constrain_instance(res.inner.clone().cell(), config.common.instance, 8)?;
+			lb.constrain_instance(res.inner.cell(), config.common.instance, 8)?;
 			drop(lb);
 
 			let res = poseidon_read.read_ec_point().unwrap();
@@ -857,7 +857,7 @@ mod test {
 
 			let res = poseidon_read.read_scalar().unwrap();
 			let mut lb = layouter_rc.lock().unwrap();
-			lb.constrain_instance(res.inner.clone().cell(), config.common.instance, 17)?;
+			lb.constrain_instance(res.inner.cell(), config.common.instance, 17)?;
 			Ok(())
 		}
 	}

--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -146,7 +146,7 @@ pub fn att_data_from_signed_att(
 	let key = signed_attestation.attestation.key.to_bytes();
 
 	// Get the payload bytes
-	let payload = AttestationPayload::from_signed_attestation(&signed_attestation)?;
+	let payload = AttestationPayload::from_signed_attestation(signed_attestation)?;
 
 	Ok(ContractAttestationData(
 		address,
@@ -273,7 +273,7 @@ mod tests {
 			message: [0u8; 32],
 		};
 
-		let bytes = payload.clone().to_bytes();
+		let bytes = payload.to_bytes();
 
 		let result_payload = AttestationPayload::from_bytes(bytes).unwrap();
 

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -127,7 +127,7 @@ impl AttestData {
 				message.to_string()
 			};
 
-			let message_bytes = hex::decode(&message).map_err(|_| "Failed to parse message.")?;
+			let message_bytes = hex::decode(message).map_err(|_| "Failed to parse message.")?;
 			if message_bytes.len() > 32 {
 				return Err("Message too long.");
 			}

--- a/client/src/eth.rs
+++ b/client/src/eth.rs
@@ -159,7 +159,7 @@ pub fn ecdsa_secret_from_mnemonic(
 		keys.push(secret_key);
 	}
 
-	return Ok(keys);
+	Ok(keys)
 }
 
 /// Construct an Ethereum address for the given ECDSA public key

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -19,6 +19,31 @@
 //! The library is implemented according to the original [Eigen Trust paper](http://ilpubs.stanford.edu:8090/562/1/2002-56.pdf).
 //! It is developed under the Ethereum Foundation grant.
 
+// Rustc
+#![warn(trivial_casts)]
+// #![deny(
+// 	absolute_paths_not_starting_with_crate, deprecated, future_incompatible, missing_docs,
+// 	nonstandard_style, unreachable_code, unreachable_patterns
+// )]
+#![forbid(unsafe_code)]
+// Clippy
+// #![allow(clippy::tabs_in_doc_comments)]
+// #![deny(
+// 	// Complexity
+// 	clippy::unnecessary_cast,
+// 	// clippy::needless_question_mark,
+// 	// Pedantic
+// 	clippy::cast_lossless,
+// 	clippy::cast_possible_wrap,
+// 	// Perf
+// 	clippy::redundant_clone,
+// 	// Restriction
+// 	clippy::panic,
+// 	// Style
+// 	// clippy::let_and_return,
+// 	// clippy::needless_borrow
+// )]
+
 pub mod att_station;
 pub mod attestation;
 pub mod error;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -28,7 +28,7 @@
 #![forbid(unsafe_code)]
 // Clippy
 // #![allow(clippy::tabs_in_doc_comments)]
-// #![deny(
+#![deny(
 // 	// Complexity
 // 	clippy::unnecessary_cast,
 // 	// clippy::needless_question_mark,
@@ -36,13 +36,13 @@
 // 	clippy::cast_lossless,
 // 	clippy::cast_possible_wrap,
 // 	// Perf
-// 	clippy::redundant_clone,
+	clippy::redundant_clone,
 // 	// Restriction
 // 	clippy::panic,
 // 	// Style
 // 	// clippy::let_and_return,
 // 	// clippy::needless_borrow
-// )]
+)]
 
 pub mod att_station;
 pub mod attestation;
@@ -73,11 +73,11 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// Max amount of participants
-const MAX_NEIGHBOURS: usize = 2;
+const _MAX_NEIGHBOURS: usize = 2;
 /// Number of iterations to run the eigen trust algorithm
-const NUM_ITERATIONS: usize = 10;
+const _NUM_ITERATIONS: usize = 10;
 /// Initial score for each participant before the algorithms is run
-const INITIAL_SCORE: u128 = 1000;
+const _INITIAL_SCORE: u128 = 1000;
 
 #[derive(Serialize, Deserialize, Debug, EthDisplay, Clone)]
 pub struct ClientConfig {
@@ -166,7 +166,7 @@ impl Client {
 				AttestationPayload::from_bytes(att_created.val.to_vec()).expect("Failed to decode");
 
 			let att = Attestation::new(
-				att_created.about.into(),
+				att_created.about,
 				att_created.key.into(),
 				att_data.get_value(),
 				Some(att_data.get_message().into()),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,18 +1,24 @@
+# Rustfmt configuration file
+# https://rust-lang.github.io/rustfmt/
+
+# Stable
 array_width = 90
-chain_width = 90
 attr_fn_like_width = 90
+chain_width = 90
 fn_params_layout = "Compressed"
 hard_tabs = true
-use_field_init_shorthand = true
 match_block_trailing_comma = true
 short_array_element_width_threshold = 40
 single_line_if_else_max_width = 80
 struct_lit_width = 80
 struct_variant_width = 80
-condense_wildcard_suffixes = true
-format_code_in_doc_comments = true
-imports_granularity="Crate"
-overflow_delimited_expr = true
-reorder_impl_items = true
-wrap_comments = true
-format_strings = true
+use_field_init_shorthand = true
+
+# Unstable
+# condense_wildcard_suffixes = true
+# format_code_in_doc_comments = true
+# format_strings = true
+# imports_granularity = "Crate"
+# overflow_delimited_expr = true
+# reorder_impl_items = true
+# wrap_comments = true 


### PR DESCRIPTION
# Related Issues

- Resolves #240 

# Description

Adds the clippy lint rule `redundant_clone`. Checks for a redundant `clone()` (and its relatives) which clones an owned value that is going to be dropped without further use.

# Changes

- Add clippy deny lint rule for `redundant_clone`
- Fix errors
- Add commented circuit lint rules to the client, as a TODO for a future issue/PR