### PR TITLE
Create `opinion` module

### DIFF
--- a/circuit/src/lib.rs
+++ b/circuit/src/lib.rs
@@ -41,6 +41,8 @@ pub mod gadgets;
 pub mod integer;
 /// MerkleTree
 pub mod merkle_tree;
+/// Opinion gadgets + native version
+pub mod opinion;
 /// A module for defining round parameters and MDS matrix for hash
 /// permutations
 pub mod params;

--- a/circuit/src/opinion/mod.rs
+++ b/circuit/src/opinion/mod.rs
@@ -1,0 +1,2 @@
+/// Native version of Opinion
+pub mod native;

--- a/circuit/src/opinion/native.rs
+++ b/circuit/src/opinion/native.rs
@@ -1,0 +1,58 @@
+use halo2::halo2curves::bn256::Fr;
+use secp256k1::PublicKey;
+
+use crate::{
+	circuit::PoseidonNativeSponge,
+	dynamic_sets::ecdsa_native::{
+		recover_ethereum_address_from_pk, AttestationFr, SignedAttestation,
+	},
+};
+
+/// Opinion info of peer
+pub struct Opinion {
+	from: PublicKey,
+	attestations: Vec<SignedAttestation>,
+}
+
+impl Opinion {
+	/// Construct new instance
+	pub fn new(from: PublicKey, attestations: Vec<SignedAttestation>) -> Self {
+		Self { from, attestations }
+	}
+
+	/// Validate attestations & calculate the hash
+	pub fn validate(&self, set: Vec<Fr>) -> (Fr, Vec<Fr>, Fr) {
+		let from_pk = recover_ethereum_address_from_pk(self.from);
+
+		let pos_from = set.iter().position(|&x| x == from_pk);
+		assert!(pos_from.is_some());
+
+		let mut scores = vec![Fr::zero(); set.len()];
+		let mut hashes = Vec::new();
+		let default_hash = AttestationFr::default().hash();
+		for (i, att) in self.attestations.iter().enumerate() {
+			let is_default_pubkey = set[i] == Fr::zero();
+
+			if is_default_pubkey {
+				scores[i] = Fr::default();
+				hashes.push(default_hash);
+			} else {
+				assert!(att.attestation.about == set[i]);
+
+				let recovered = att.recover_public_key().unwrap();
+				assert!(recovered == self.from);
+
+				scores[i] = att.attestation.value;
+
+				let hash = att.attestation.hash();
+				hashes.push(hash);
+			}
+		}
+
+		let mut sponge_hasher = PoseidonNativeSponge::new();
+		sponge_hasher.update(&hashes);
+		let op_hash = sponge_hasher.squeeze();
+
+		(from_pk, scores, op_hash)
+	}
+}


### PR DESCRIPTION
## Description
- Create `opinion` module inside the `circuit` codebase
- Move the `update_op` logic to `opinion` module

Closes #232 

## Changes
- Create files for native and halo2 version of `Opinion` module
- Implement the native version of `Opinion`