### PR TITLE
feat: attestation key from domain

### DIFF
--- a/circuit/src/dynamic_sets/native.rs
+++ b/circuit/src/dynamic_sets/native.rs
@@ -54,7 +54,7 @@ pub struct AttestationFr {
 	/// Ethereum address of peer being rated
 	pub about: Fr,
 	/// Unique identifier for the action being rated
-	pub key: Fr,
+	pub domain: Fr,
 	/// Given rating for the action
 	pub value: Fr,
 	/// Optional field for attaching additional information to the attestation
@@ -63,13 +63,13 @@ pub struct AttestationFr {
 
 impl AttestationFr {
 	/// Construct a new attestation struct
-	pub fn new(about: Fr, key: Fr, value: Fr, message: Fr) -> Self {
-		Self { about, key, value, message }
+	pub fn new(about: Fr, domain: Fr, value: Fr, message: Fr) -> Self {
+		Self { about, domain, value, message }
 	}
 
 	/// Hash attestation
 	pub fn hash(&self) -> Fr {
-		PoseidonNativeHasher::new([self.about, self.key, self.value, self.message, Fr::zero()])
+		PoseidonNativeHasher::new([self.about, self.domain, self.value, self.message, Fr::zero()])
 			.permute()[0]
 	}
 }

--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -37,11 +37,17 @@ impl Attestation {
 		let mut about_bytes_array = [0u8; 32];
 		about_bytes_array[..about_bytes.len()].copy_from_slice(about_bytes);
 
+		let mut key = [0u8; 32];
+		self.key.to_little_endian(&mut key);
+
+		let mut message = [0u8; 32];
+		self.message.to_little_endian(&mut message);
+
 		AttestationFr {
 			about: Scalar::from_bytes(&about_bytes_array).unwrap(),
-			key: Scalar::from(self.key.0[0]),
+			key: Scalar::from_bytes(&key).unwrap(),
 			value: Scalar::from(self.value as u64),
-			message: Scalar::from(self.message.0[0]),
+			message: Scalar::from_bytes(&message).unwrap(),
 		}
 	}
 }

--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -8,6 +8,11 @@ use eigen_trust_circuit::{
 use ethers::types::{Address, U256};
 use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 
+/// Domain prefix length
+pub const DOMAIN_PREFIX_LEN: usize = 12;
+/// Domain prefix
+pub const DOMAIN_PREFIX: [u8; DOMAIN_PREFIX_LEN] = *b"eigen_trust_";
+
 /// Attestation struct
 #[derive(Clone, Debug)]
 pub struct Attestation {

--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -185,7 +185,7 @@ mod tests {
 	use ethers::{
 		prelude::k256::ecdsa::SigningKey,
 		signers::{Signer, Wallet},
-		types::{Bytes, H160},
+		types::Bytes,
 	};
 	use secp256k1::{ecdsa::RecoveryId, Message, Secp256k1, SecretKey};
 
@@ -194,19 +194,18 @@ mod tests {
 		// Build key
 		let domain_input = [
 			0x4c, 0x61, 0x4a, 0x6d, 0x59, 0x56, 0x2a, 0x42, 0x37, 0x72, 0x37, 0x76, 0x32, 0x4d,
-			0x36, 0x53, 0x62, 0x6d, 0x35, 0x37,
+			0x36, 0x53, 0x62, 0x6d, 0x35, 0x00,
 		];
-		let domain = H160::from(domain_input);
 
 		let mut key_bytes: [u8; 32] = [0; 32];
 		key_bytes[..DOMAIN_PREFIX_LEN].copy_from_slice(&DOMAIN_PREFIX);
-		key_bytes[DOMAIN_PREFIX_LEN..].copy_from_slice(domain.as_bytes());
+		key_bytes[DOMAIN_PREFIX_LEN..].copy_from_slice(&domain_input);
 
 		// Message input
 		let message = [
 			0x31, 0x75, 0x32, 0x45, 0x75, 0x79, 0x32, 0x77, 0x7a, 0x34, 0x58, 0x6c, 0x34, 0x34,
 			0x4a, 0x74, 0x6a, 0x78, 0x68, 0x4c, 0x4a, 0x52, 0x67, 0x48, 0x45, 0x6c, 0x4e, 0x73,
-			0x65, 0x6e, 0x79, 0x64,
+			0x65, 0x6e, 0x79, 0x00,
 		];
 
 		// Address Input
@@ -229,7 +228,7 @@ mod tests {
 		let expected_about = Scalar::from_bytes(&expected_about_input).unwrap();
 
 		let mut expected_domain_input = [0u8; 32];
-		expected_domain_input[12..32].copy_from_slice(domain.as_bytes());
+		expected_domain_input[12..].copy_from_slice(&domain_input);
 		let expected_domain = Scalar::from_bytes(&expected_domain_input).unwrap();
 
 		let expected_value = Scalar::from(10u64);
@@ -384,12 +383,7 @@ mod tests {
 		let secret_key =
 			SecretKey::from_slice(&secret_key_as_bytes).expect("32 bytes, within curve order");
 
-		let attestation = Attestation::new(
-			Address::zero(),
-			U256::from(140317563),
-			10,
-			Some(U256::from(140317564)),
-		);
+		let attestation = Attestation::new(Address::zero(), U256::from(0), 10, Some(U256::from(0)));
 
 		let message = attestation.to_attestation_fr().unwrap().hash().to_bytes();
 

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -136,7 +136,7 @@ impl AttestData {
 		let domain = H160::from_str(&config.domain).map_err(|_| "Failed to parse domain")?;
 		let mut key_bytes: [u8; 32] = [0; 32];
 		key_bytes[..DOMAIN_PREFIX_LEN].copy_from_slice(&DOMAIN_PREFIX);
-		key_bytes[DOMAIN_PREFIX_LEN..].copy_from_slice(&domain.as_bytes());
+		key_bytes[DOMAIN_PREFIX_LEN..].copy_from_slice(domain.as_bytes());
 		let key = U256::from(key_bytes);
 
 		Ok(Attestation::new(parsed_address, key, parsed_score, message))

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -1,12 +1,12 @@
 use crate::ClientConfig;
 use clap::{Args, Parser, Subcommand};
 use eigen_trust_circuit::utils::write_json_data;
-use eigen_trust_client::attestation::Attestation;
+use eigen_trust_client::attestation::{Attestation, DOMAIN_PREFIX, DOMAIN_PREFIX_LEN};
 use ethers::{
 	abi::Address,
 	providers::Http,
 	signers::coins_bip39::{English, Mnemonic},
-	utils::hex,
+	types::{H160, U256},
 };
 use std::str::FromStr;
 
@@ -42,6 +42,9 @@ pub struct UpdateData {
 	/// Address of the AttestationStation contract (20-byte ethereum address)
 	#[clap(long = "as-address")]
 	as_address: Option<String>,
+	/// Domain id (20-byte hex string)
+	#[clap(long = "domain")]
+	domain: Option<String>,
 	/// Ethereum wallet mnemonic phrase
 	#[clap(long = "mnemonic")]
 	mnemonic: Option<String>,
@@ -58,6 +61,11 @@ pub fn handle_update(config: &mut ClientConfig, data: UpdateData) -> Result<(), 
 	if let Some(as_address) = data.as_address {
 		config.as_address =
 			Address::from_str(&as_address).map_err(|_| "Failed to parse address.")?.to_string();
+	}
+
+	if let Some(domain) = data.domain {
+		config.as_address =
+			H160::from_str(&domain).map_err(|_| "Failed to parse domain")?.to_string();
 	}
 
 	if let Some(mnemonic) = data.mnemonic {
@@ -98,7 +106,7 @@ pub struct AttestData {
 
 impl AttestData {
 	/// Converts `AttestData` to `Attestation`
-	pub fn to_attestation(&self) -> Result<Attestation, &'static str> {
+	pub fn to_attestation(&self, config: &ClientConfig) -> Result<Attestation, &'static str> {
 		// Parse Address
 		let parsed_address: Address = self
 			.address
@@ -116,43 +124,71 @@ impl AttestData {
 			.map_err(|_| "Failed to parse score. It must be a number between 0 and 255.")?;
 
 		// Parse message
-		let mut message_array = [0u8; 32];
-		if let Some(message) = &self.message {
-			let message = message.trim_start_matches("0x");
+		let message = match &self.message {
+			Some(message_str) => {
+				let message = U256::from_str(message_str).map_err(|_| "Failed to parse message")?;
+				Some(message)
+			},
+			None => None,
+		};
 
-			// If the message has an odd number of characters, prepend a '0'
-			let message = if message.len() % 2 == 1 {
-				format!("0{}", message)
-			} else {
-				message.to_string()
-			};
+		// Key
+		let domain = H160::from_str(&config.domain).map_err(|_| "Failed to parse domain")?;
+		let mut key_bytes: [u8; 32] = [0; 32];
+		key_bytes[..DOMAIN_PREFIX_LEN].copy_from_slice(&DOMAIN_PREFIX);
+		key_bytes[DOMAIN_PREFIX_LEN..].copy_from_slice(&domain.as_bytes());
+		let key = U256::from(key_bytes);
 
-			let message_bytes = hex::decode(message).map_err(|_| "Failed to parse message.")?;
-			if message_bytes.len() > 32 {
-				return Err("Message too long.");
-			}
-
-			// Calculate the starting index for the copy operation
-			let start_index = 32 - message_bytes.len();
-			message_array[start_index..].copy_from_slice(&message_bytes);
-		}
-
-		Ok(Attestation::new(
-			parsed_address,
-			[0; 32].into(),
-			parsed_score,
-			Some(message_array.into()),
-		))
+		Ok(Attestation::new(parsed_address, key, parsed_score, message))
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use crate::cli::Cli;
+	use crate::cli::{AttestData, Cli};
 	use clap::CommandFactory;
+	use eigen_trust_client::{attestation::DOMAIN_PREFIX, ClientConfig};
+	use ethers::types::U256;
+	use std::str::FromStr;
 
 	#[test]
 	fn test_cli() {
 		Cli::command().debug_assert()
+	}
+
+	#[test]
+	fn test_attest_data_to_attestation() {
+		let config = ClientConfig {
+			as_address: "test".to_string(),
+			domain: "0x0000000000000000000000000000000000000000".to_string(),
+			mnemonic: "test".to_string(),
+			node_url: "http://localhost:8545".to_string(),
+			verifier_address: "test".to_string(),
+		};
+
+		let data = AttestData {
+			address: Some("0x5fbdb2315678afecb367f032d93f642f64180aa3".to_string()),
+			score: Some("5".to_string()),
+			message: Some("0x1234512345".to_string()),
+			key: None,
+		};
+
+		let attestation = data.to_attestation(&config).unwrap();
+
+		assert_eq!(
+			attestation.about,
+			"0x5fbdb2315678afecb367f032d93f642f64180aa3".parse().unwrap()
+		);
+		assert_eq!(attestation.value, 5);
+
+		let mut expected_key_bytes: [u8; 32] = [0; 32];
+		expected_key_bytes[..DOMAIN_PREFIX.len()].copy_from_slice(&DOMAIN_PREFIX);
+		let expected_key = U256::from(expected_key_bytes);
+
+		assert_eq!(attestation.key, expected_key);
+
+		let expected_message = U256::from_str(&"0x1234512345".to_string()).unwrap();
+
+		assert_eq!(attestation.message, expected_message);
 	}
 }

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -99,9 +99,6 @@ pub struct AttestData {
 	/// Attestation message (hex-encoded)
 	#[clap(long = "message")]
 	message: Option<String>,
-	/// Attestation key
-	#[clap(long = "key")]
-	key: Option<String>,
 }
 
 impl AttestData {
@@ -170,7 +167,6 @@ mod tests {
 			address: Some("0x5fbdb2315678afecb367f032d93f642f64180aa3".to_string()),
 			score: Some("5".to_string()),
 			message: Some("0x1234512345".to_string()),
-			key: None,
 		};
 
 		let attestation = data.to_attestation(&config).unwrap();

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -111,7 +111,7 @@ impl Client {
 			ecdsa_secret_from_mnemonic(&self.config.mnemonic, 1).unwrap();
 
 		// Get AttestationFr
-		let attestation_fr = attestation.to_attestation_fr();
+		let attestation_fr = attestation.to_attestation_fr().unwrap();
 
 		// Format for signature
 		let att_hash = attestation_fr.hash();

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -82,6 +82,7 @@ const _INITIAL_SCORE: u128 = 1000;
 #[derive(Serialize, Deserialize, Debug, EthDisplay, Clone)]
 pub struct ClientConfig {
 	pub as_address: String,
+	pub domain: String,
 	pub mnemonic: String,
 	pub node_url: String,
 	pub verifier_address: String,
@@ -217,6 +218,7 @@ mod lib_tests {
 
 		let config = ClientConfig {
 			as_address: format!("{:?}", as_address),
+			domain: "0x0000000000000000000000000000000000000000".to_string(),
 			mnemonic: mnemonic.clone(),
 			node_url,
 			verifier_address: format!("{:?}", verifier_address),

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
 		Mode::Attest(attest_data) => {
 			println!("Creating attestation...\n{:#?}", attest_data);
 
-			let attestation = match attest_data.to_attestation() {
+			let attestation = match attest_data.to_attestation(&config) {
 				Ok(a) => a,
 				Err(e) => {
 					println!("Error while creating attestation: {:?}", e);
@@ -32,7 +32,7 @@ async fn main() {
 
 			println!("Attesting...\n{:?}", attestation);
 
-			let client = Client::new(config.clone());
+			let client = Client::new(config);
 			if let Err(e) = client.attest(attestation).await {
 				println!("Error while attesting: {:?}", e);
 			}

--- a/data/client-config.json
+++ b/data/client-config.json
@@ -1,5 +1,6 @@
 {
   "as_address": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+  "domain": "0x0000000000000000000000000000000000000000",
   "mnemonic": "test test test test test test test test test test test junk",
   "node_url": "http://localhost:8545",
   "verifier_address": "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"


### PR DESCRIPTION
# Related Issues

- Resolves #239 

# Description

This PR enables the creation of the attestation 32-byte `key` value from a 12-byte pre-defined `DOMAIN_PREFIX` and a 20-byte `domain` identifier configurable by the user.

# Changes

- Adds `domain` to `client-config`.
- Updates CLI for client configuration.
- Updates attestation creation from `attest` command.
- Adds `test_attest_data_to_attestation()`.