### PR TITLE
feat: `calculate_scores`

### DIFF
--- a/circuit/src/dynamic_sets/ecdsa_native.rs
+++ b/circuit/src/dynamic_sets/ecdsa_native.rs
@@ -48,7 +48,7 @@ pub fn field_value_from_pub_key(&pub_key: &ECDSAPublicKey) -> Fr {
 }
 
 /// Attestation submission struct
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SignedAttestation {
 	/// Attestation
 	pub attestation: AttestationFr,

--- a/circuit/src/dynamic_sets/ecdsa_native.rs
+++ b/circuit/src/dynamic_sets/ecdsa_native.rs
@@ -38,7 +38,8 @@ pub fn address_from_pub_key(pub_key: &ECDSAPublicKey) -> Result<[u8; 20], &'stat
 
 /// Calculate the address field value from a public key
 pub fn field_value_from_pub_key(&pub_key: &ECDSAPublicKey) -> Fr {
-	let address = address_from_pub_key(&pub_key).unwrap();
+	let mut address = address_from_pub_key(&pub_key).unwrap();
+	address.reverse();
 
 	let mut address_bytes = [0u8; 32];
 	address_bytes[..address.len()].copy_from_slice(&address);
@@ -94,7 +95,7 @@ pub struct AttestationFr {
 	/// Ethereum address of peer being rated
 	pub about: Fr,
 	/// Unique identifier for the action being rated
-	pub key: Fr,
+	pub domain: Fr,
 	/// Given rating for the action
 	pub value: Fr,
 	/// Optional field for attaching additional information to the attestation
@@ -103,13 +104,13 @@ pub struct AttestationFr {
 
 impl AttestationFr {
 	/// Construct a new attestation struct
-	pub fn new(about: Fr, key: Fr, value: Fr, message: Fr) -> Self {
-		Self { about, key, value, message }
+	pub fn new(about: Fr, domain: Fr, value: Fr, message: Fr) -> Self {
+		Self { about, domain, value, message }
 	}
 
 	/// Hash attestation
 	pub fn hash(&self) -> Fr {
-		PoseidonNativeHasher::new([self.about, self.key, self.value, self.message, Fr::zero()])
+		PoseidonNativeHasher::new([self.about, self.domain, self.value, self.message, Fr::zero()])
 			.permute()[0]
 	}
 }
@@ -118,7 +119,7 @@ impl Default for AttestationFr {
 	fn default() -> Self {
 		AttestationFr {
 			about: Fr::default(),
-			key: Fr::default(),
+			domain: Fr::default(),
 			value: Fr::default(),
 			message: Fr::default(),
 		}

--- a/circuit/src/dynamic_sets/ecdsa_native.rs
+++ b/circuit/src/dynamic_sets/ecdsa_native.rs
@@ -22,11 +22,11 @@ pub type ECDSASignature = ecdsa::RecoverableSignature;
 
 /// Construct an Ethereum address for the given ECDSA public key
 pub fn address_from_pub_key(pub_key: &ECDSAPublicKey) -> Result<[u8; 20], &'static str> {
-	let pub_key_bytes = pub_key.serialize_uncompressed();
+	let pub_key_bytes: [u8; 65] = pub_key.serialize_uncompressed();
 
 	// Hash with Keccak256
 	let mut hasher = Keccak256::new();
-	hasher.update(pub_key_bytes);
+	hasher.update(&pub_key_bytes[1..]);
 	let hashed_public_key = hasher.finalize().to_vec();
 
 	// Get the last 20 bytes of the hash

--- a/circuit/src/opinion/native.rs
+++ b/circuit/src/opinion/native.rs
@@ -22,9 +22,6 @@ impl Opinion {
 	pub fn validate(&self, set: Vec<Fr>) -> (Fr, Vec<Fr>, Fr) {
 		let from_pk = field_value_from_pub_key(&self.from);
 
-		println!("from_pk: {:?}", from_pk);
-		println!("set: {:?}", set);
-
 		let pos_from = set.iter().position(|&x| x == from_pk);
 		assert!(pos_from.is_some());
 

--- a/circuit/src/opinion/native.rs
+++ b/circuit/src/opinion/native.rs
@@ -22,6 +22,9 @@ impl Opinion {
 	pub fn validate(&self, set: Vec<Fr>) -> (Fr, Vec<Fr>, Fr) {
 		let from_pk = field_value_from_pub_key(&self.from);
 
+		println!("from_pk: {:?}", from_pk);
+		println!("set: {:?}", set);
+
 		let pos_from = set.iter().position(|&x| x == from_pk);
 		assert!(pos_from.is_some());
 

--- a/circuit/src/opinion/native.rs
+++ b/circuit/src/opinion/native.rs
@@ -7,12 +7,12 @@ use crate::{
 };
 
 /// Opinion info of peer
-pub struct Opinion {
+pub struct Opinion<const NUM_NEIGHBOURS: usize> {
 	from: PublicKey,
 	attestations: Vec<SignedAttestation>,
 }
 
-impl Opinion {
+impl<const NUM_NEIGHBOURS: usize> Opinion<NUM_NEIGHBOURS> {
 	/// Construct new instance
 	pub fn new(from: PublicKey, attestations: Vec<SignedAttestation>) -> Self {
 		Self { from, attestations }
@@ -27,11 +27,16 @@ impl Opinion {
 
 		let mut scores = vec![Fr::zero(); set.len()];
 		let mut hashes = Vec::new();
-		let default_hash = AttestationFr::default().hash();
-		for (i, att) in self.attestations.iter().enumerate() {
+
+		let default_att = SignedAttestation::default();
+		let default_hash = default_att.attestation.hash();
+		for i in 0..NUM_NEIGHBOURS {
 			let is_default_pubkey = set[i] == Fr::zero();
 
-			if is_default_pubkey {
+			let att = self.attestations[i].clone();
+			let is_default_sig = att.attestation == AttestationFr::default();
+
+			if is_default_pubkey || is_default_sig {
 				scores[i] = Fr::default();
 				hashes.push(default_hash);
 			} else {

--- a/circuit/src/opinion/native.rs
+++ b/circuit/src/opinion/native.rs
@@ -3,9 +3,7 @@ use secp256k1::PublicKey;
 
 use crate::{
 	circuit::PoseidonNativeSponge,
-	dynamic_sets::ecdsa_native::{
-		recover_ethereum_address_from_pk, AttestationFr, SignedAttestation,
-	},
+	dynamic_sets::ecdsa_native::{field_value_from_pub_key, AttestationFr, SignedAttestation},
 };
 
 /// Opinion info of peer
@@ -22,7 +20,7 @@ impl Opinion {
 
 	/// Validate attestations & calculate the hash
 	pub fn validate(&self, set: Vec<Fr>) -> (Fr, Vec<Fr>, Fr) {
-		let from_pk = recover_ethereum_address_from_pk(self.from);
+		let from_pk = field_value_from_pub_key(&self.from);
 
 		let pos_from = set.iter().position(|&x| x == from_pk);
 		assert!(pos_from.is_some());

--- a/client/README.md
+++ b/client/README.md
@@ -57,7 +57,7 @@ The command-line interface was built using [clap.rs](http://clap.rs/). There is 
 - `attest`: Submits an attestation. Takes the following options:
   - `--to`: Specify the attested address.
   - `--score`: Specify the given score (between 0 and 255).
-  - `--message`: Specify an optional message in hexadecimal format.
+  - `--message`: Specify an optional 32-byte message in hexadecimal format.
 - `compile`: Compiles all the `.sol` and `.yul` contracts available in the `data` folder. For `.sol` contracts, it generates an ABI JSON file and a Rust binding file. For `.yul` smart contracts, it compiles Yul code into binary.
 - `deploy`: Deploys all the contracts.
 - `proof`: Calculates the global scores, generates the zk proof and stores it in `et-proof.json` at the `data` directory.
@@ -79,7 +79,7 @@ cargo run --release -- update --node http://localhost:8545
 ### Example of `attest` command
 
 ```bash
-cargo run --release -- attest --to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 --score 5 --message 0x68656c6c6f
+cargo run --release -- attest --to 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 --score 5 --message 0x473fe1d0de78c8f334d059013d902c13c8b53eb0f669caa9cad677ce1a601167
 ```
 
 ## Configuration

--- a/client/README.md
+++ b/client/README.md
@@ -61,6 +61,7 @@ The command-line interface was built using [clap.rs](http://clap.rs/). There is 
 - `compile`: Compiles all the `.sol` and `.yul` contracts available in the `data` folder. For `.sol` contracts, it generates an ABI JSON file and a Rust binding file. For `.yul` smart contracts, it compiles Yul code into binary.
 - `deploy`: Deploys all the contracts.
 - `proof`: Calculates the global scores, generates the zk proof and stores it in `et-proof.json` at the `data` directory.
+- `scores`: Calculates the global scores and stores them in the `scores.csv` file within the data directory.
 - `show`: Displays the `client-config.json` file.
 - `update`: Updates the specified field in `client-config.json`. Takes the following options:
   - `--as-address`: Updates the address of the AttestationStation contract.

--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -1,8 +1,9 @@
 use crate::{
-	att_station::AttestationData as ContractAttestationData, eth::address_from_public_key,
+	att_station::AttestationData as ContractAttestationData,
+	eth::{address_from_public_key, scalar_from_address},
 };
 use eigen_trust_circuit::{
-	dynamic_sets::native::{AttestationFr, SignedAttestation},
+	dynamic_sets::ecdsa_native::{AttestationFr, SignedAttestation},
 	halo2::halo2curves::{bn256::Fr as Scalar, ff::FromUniformBytes},
 };
 use ethers::types::{Address, U256};
@@ -35,16 +36,7 @@ impl Attestation {
 	/// Convert to scalar representation
 	pub fn to_attestation_fr(&self) -> Result<AttestationFr, &'static str> {
 		// About
-		let mut about_le_bytes = self.about.to_fixed_bytes();
-		about_le_bytes.reverse();
-
-		let mut about_bytes = [0u8; 32];
-		about_bytes[..20].copy_from_slice(&about_le_bytes);
-
-		let about = match Scalar::from_bytes(&about_bytes).is_some().into() {
-			true => Scalar::from_bytes(&about_bytes).unwrap(),
-			false => return Err("Failed to convert about address to scalar"),
-		};
+		let about = scalar_from_address(&self.about)?;
 
 		// Domain
 		let mut key_bytes = [0u8; 32];

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -6,7 +6,7 @@ use ethers::{
 	abi::Address,
 	providers::Http,
 	signers::coins_bip39::{English, Mnemonic},
-	types::{H160, U256},
+	types::{H160, H256},
 };
 use std::str::FromStr;
 
@@ -123,7 +123,7 @@ impl AttestData {
 		// Parse message
 		let message = match &self.message {
 			Some(message_str) => {
-				let message = U256::from_str(message_str).map_err(|_| "Failed to parse message")?;
+				let message = H256::from_str(message_str).map_err(|_| "Failed to parse message")?;
 				Some(message)
 			},
 			None => None,
@@ -134,7 +134,7 @@ impl AttestData {
 		let mut key_bytes: [u8; 32] = [0; 32];
 		key_bytes[..DOMAIN_PREFIX_LEN].copy_from_slice(&DOMAIN_PREFIX);
 		key_bytes[DOMAIN_PREFIX_LEN..].copy_from_slice(domain.as_bytes());
-		let key = U256::from(key_bytes);
+		let key = H256::from(key_bytes);
 
 		Ok(Attestation::new(parsed_address, key, parsed_score, message))
 	}
@@ -145,7 +145,7 @@ mod tests {
 	use crate::cli::{AttestData, Cli};
 	use clap::CommandFactory;
 	use eigen_trust_client::{attestation::DOMAIN_PREFIX, ClientConfig};
-	use ethers::types::U256;
+	use ethers::types::H256;
 	use std::str::FromStr;
 
 	#[test]
@@ -166,7 +166,9 @@ mod tests {
 		let data = AttestData {
 			address: Some("0x5fbdb2315678afecb367f032d93f642f64180aa3".to_string()),
 			score: Some("5".to_string()),
-			message: Some("0x1234512345".to_string()),
+			message: Some(
+				"473fe1d0de78c8f334d059013d902c13c8b53eb0f669caa9cad677ce1a601167".to_string(),
+			),
 		};
 
 		let attestation = data.to_attestation(&config).unwrap();
@@ -179,11 +181,14 @@ mod tests {
 
 		let mut expected_key_bytes: [u8; 32] = [0; 32];
 		expected_key_bytes[..DOMAIN_PREFIX.len()].copy_from_slice(&DOMAIN_PREFIX);
-		let expected_key = U256::from(expected_key_bytes);
+		let expected_key = H256::from(expected_key_bytes);
 
 		assert_eq!(attestation.key, expected_key);
 
-		let expected_message = U256::from_str(&"0x1234512345".to_string()).unwrap();
+		let expected_message = H256::from_str(
+			&"473fe1d0de78c8f334d059013d902c13c8b53eb0f669caa9cad677ce1a601167".to_string(),
+		)
+		.unwrap();
 
 		assert_eq!(attestation.message, expected_message);
 	}

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -28,6 +28,8 @@ pub enum Mode {
 	Deploy,
 	/// Generate the proofs
 	Proof,
+	/// Calculate the global scores
+	Scores,
 	/// Display the current client configuration
 	Show,
 	/// Update the client configuration. Requires 'UpdateData'

--- a/client/src/eth.rs
+++ b/client/src/eth.rs
@@ -158,6 +158,22 @@ pub fn address_from_public_key(pub_key: &ECDSAPublicKey) -> Result<Address, &'st
 	Ok(Address::from_slice(address_bytes))
 }
 
+/// Construct a Scalar from the given Ethereum address
+pub fn scalar_from_address(address: &Address) -> Result<Scalar, &'static str> {
+	let mut address_le_bytes = address.to_fixed_bytes();
+	address_le_bytes.reverse();
+
+	let mut address_bytes = [0u8; 32];
+	address_bytes[..address_le_bytes.len()].copy_from_slice(&address_le_bytes);
+
+	let about = match Scalar::from_bytes(&address_bytes).is_some().into() {
+		true => Scalar::from_bytes(&address_bytes).unwrap(),
+		false => return Err("Failed to convert about address to scalar"),
+	};
+
+	Ok(about)
+}
+
 #[cfg(test)]
 mod tests {
 	use crate::eth::{address_from_public_key, call_verifier, deploy_as, deploy_verifier};

--- a/client/src/eth.rs
+++ b/client/src/eth.rs
@@ -160,11 +160,11 @@ pub fn address_from_public_key(pub_key: &ECDSAPublicKey) -> Result<Address, &'st
 
 /// Construct a Scalar from the given Ethereum address
 pub fn scalar_from_address(address: &Address) -> Result<Scalar, &'static str> {
-	let mut address_le_bytes = address.to_fixed_bytes();
-	address_le_bytes.reverse();
+	let mut address_fixed = address.to_fixed_bytes();
+	address_fixed.reverse();
 
 	let mut address_bytes = [0u8; 32];
-	address_bytes[..address_le_bytes.len()].copy_from_slice(&address_le_bytes);
+	address_bytes[..address_fixed.len()].copy_from_slice(&address_fixed);
 
 	let about = match Scalar::from_bytes(&address_bytes).is_some().into() {
 		true => Scalar::from_bytes(&address_bytes).unwrap(),

--- a/client/src/eth.rs
+++ b/client/src/eth.rs
@@ -147,7 +147,7 @@ pub fn ecdsa_secret_from_mnemonic(
 
 /// Construct an Ethereum address for the given ECDSA public key
 pub fn address_from_public_key(pub_key: &ECDSAPublicKey) -> Result<Address, &'static str> {
-	let pub_key_bytes = pub_key.serialize_uncompressed();
+	let pub_key_bytes: [u8; 65] = pub_key.serialize_uncompressed();
 
 	// Hash with Keccak256
 	let hashed_public_key = keccak256(&pub_key_bytes[1..]);

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -52,9 +52,12 @@ pub mod utils;
 
 use att_station::{AttestationCreatedFilter, AttestationStation};
 use attestation::{att_data_from_signed_att, Attestation, AttestationPayload};
-use eigen_trust_circuit::dynamic_sets::native::SignedAttestation;
+use eigen_trust_circuit::{
+	dynamic_sets::ecdsa_native::{ECDSAPublicKey, EigenTrustSet, SignedAttestation},
+	halo2::halo2curves::bn256::Fr as Scalar,
+};
 use error::EigenError;
-use eth::ecdsa_secret_from_mnemonic;
+use eth::{address_from_public_key, ecdsa_secret_from_mnemonic, scalar_from_address};
 use ethers::{
 	abi::{Address, RawLog},
 	contract::EthEvent,
@@ -70,14 +73,17 @@ use ethers::{
 };
 use secp256k1::{ecdsa::RecoverableSignature, Message, SecretKey, SECP256K1};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{
+	collections::{HashMap, HashSet},
+	sync::Arc,
+};
 
 /// Max amount of participants
-const _MAX_NEIGHBOURS: usize = 2;
+const MAX_NEIGHBOURS: usize = 2;
 /// Number of iterations to run the eigen trust algorithm
-const _NUM_ITERATIONS: usize = 10;
+const NUM_ITERATIONS: usize = 10;
 /// Initial score for each participant before the algorithms is run
-const _INITIAL_SCORE: u128 = 1000;
+const INITIAL_SCORE: u128 = 1000;
 
 #[derive(Serialize, Deserialize, Debug, EthDisplay, Clone)]
 pub struct ClientConfig {
@@ -128,6 +134,13 @@ impl Client {
 		let as_address = as_address_res.map_err(|_| EigenError::ParseError)?;
 		let as_contract = AttestationStation::new(as_address, self.client.clone());
 
+		// Verify signature is recoverable
+		let recovered_pubkey = signed_attestation.recover_public_key().unwrap();
+		let recovered_address = address_from_public_key(&recovered_pubkey).unwrap();
+		println!("Recovered address: {:?}", recovered_address);
+		println!("Client address: {:?}", self.client.address());
+		assert!(recovered_address == self.client.address());
+
 		let tx_call =
 			as_contract.attest(vec![att_data_from_signed_att(&signed_attestation).unwrap()]);
 		let tx_res = tx_call.send();
@@ -141,9 +154,68 @@ impl Client {
 		Ok(())
 	}
 
-	/// Calculate proofs
-	pub async fn calculate_proofs(&mut self) -> Result<(), EigenError> {
-		// TODO: Implement
+	/// Calculate scores
+	pub async fn calculate_scores(&mut self) -> Result<(), EigenError> {
+		// Get attestations
+		let attestations = self.get_attestations().await?;
+
+		// Get participants
+		let mut participants_set = HashSet::<Address>::new();
+
+		for (signed_att, att) in attestations.iter() {
+			// Add attested
+			participants_set.insert(att.about);
+
+			// Add signer
+			let signer_pub_key = signed_att.recover_public_key().unwrap();
+			let signer_address = address_from_public_key(&signer_pub_key).unwrap();
+			participants_set.insert(signer_address);
+		}
+
+		// Create EigenTrustSet
+		let mut eigen_trust_set =
+			EigenTrustSet::<MAX_NEIGHBOURS, NUM_ITERATIONS, INITIAL_SCORE>::new();
+
+		// Add members to set
+		let participants: Vec<Scalar> =
+			participants_set.iter().map(|address| scalar_from_address(address).unwrap()).collect();
+
+		for participant in participants {
+			eigen_trust_set.add_member(participant);
+		}
+
+		// Update members opinions
+		// This could be done in the same step as getting the participant set
+		// Create attestation map
+		let mut attestation_map: HashMap<ECDSAPublicKey, Vec<SignedAttestation>> = HashMap::new();
+
+		for (signed_att, _) in attestations.iter() {
+			// Get signer ECDSA public key
+			let signer_pub_key = signed_att.recover_public_key().unwrap();
+
+			// Put attestation in new vector
+			let att_vec = vec![signed_att.clone()];
+
+			// If signer exist, append vector, if not, just add
+			if attestation_map.contains_key(&signer_pub_key) {
+				let mut attestation_vec = attestation_map.get(&signer_pub_key).unwrap().clone();
+				attestation_vec.extend(att_vec);
+				attestation_map.insert(signer_pub_key, attestation_vec);
+			} else {
+				attestation_map.insert(signer_pub_key, att_vec);
+			}
+		}
+
+		// Update opinions
+		for (signer_pub_key, att_vec) in attestation_map.iter() {
+			eigen_trust_set.update_op(signer_pub_key.clone(), att_vec.clone());
+		}
+
+		// Calculate scores
+		let scores = eigen_trust_set.converge();
+
+		println!("Scores: {:?}", scores);
+
 		Ok(())
 	}
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -137,8 +137,6 @@ impl Client {
 		// Verify signature is recoverable
 		let recovered_pubkey = signed_attestation.recover_public_key().unwrap();
 		let recovered_address = address_from_public_key(&recovered_pubkey).unwrap();
-		println!("Recovered address: {:?}", recovered_address);
-		println!("Client address: {:?}", self.client.address());
 		assert!(recovered_address == self.client.address());
 
 		let tx_call =

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -52,10 +52,7 @@ pub mod utils;
 
 use att_station::{AttestationCreatedFilter, AttestationStation};
 use attestation::{att_data_from_signed_att, Attestation, AttestationPayload};
-use eigen_trust_circuit::{
-	dynamic_sets::ecdsa_native::{ECDSAPublicKey, EigenTrustSet, SignedAttestation},
-	halo2::halo2curves::bn256::Fr as Scalar,
-};
+use eigen_trust_circuit::dynamic_sets::ecdsa_native::{EigenTrustSet, SignedAttestation};
 use error::EigenError;
 use eth::{address_from_public_key, ecdsa_secret_from_mnemonic, scalar_from_address};
 use ethers::{
@@ -73,13 +70,10 @@ use ethers::{
 };
 use secp256k1::{ecdsa::RecoverableSignature, Message, SecretKey, SECP256K1};
 use serde::{Deserialize, Serialize};
-use std::{
-	collections::{HashMap, HashSet},
-	sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 /// Max amount of participants
-const MAX_NEIGHBOURS: usize = 2;
+const MAX_NEIGHBOURS: usize = 3;
 /// Number of iterations to run the eigen trust algorithm
 const NUM_ITERATIONS: usize = 10;
 /// Initial score for each participant before the algorithms is run
@@ -162,6 +156,12 @@ impl Client {
 		// Get participants
 		let mut participants_set = HashSet::<Address>::new();
 
+		// Add default participant
+		participants_set.insert(
+			address_from_public_key(&SignedAttestation::default().recover_public_key().unwrap())
+				.unwrap(),
+		);
+
 		for (signed_att, att) in attestations.iter() {
 			// Add attested
 			participants_set.insert(att.about);
@@ -172,43 +172,57 @@ impl Client {
 			participants_set.insert(signer_address);
 		}
 
+		let participants: Vec<Address> = participants_set.into_iter().collect();
+		let set_len: usize = participants.len();
+
+		// Create attestation matrix
+		let mut attestation_matrix: Vec<Vec<SignedAttestation>> =
+			vec![vec![SignedAttestation::default(); set_len]; set_len];
+
+		println!("Participants: {:#?}", participants);
+
+		// Update attestations matrix
+		for (signed_att, att) in attestations.iter() {
+			// Get attester address
+			let attester_ecdsa = signed_att.recover_public_key().unwrap();
+			let attester_address = address_from_public_key(&attester_ecdsa).unwrap();
+
+			// Get attester set position
+			let attester_pos = participants.iter().position(|&r| r == attester_address).unwrap();
+
+			// Get attested set position
+			let attested_pos = participants.iter().position(|&r| r == att.about).unwrap();
+
+			// Get attester vector
+			let mut att_vec = attestation_matrix[attester_pos].clone();
+
+			// Update attested opinion
+			att_vec[attested_pos] = signed_att.clone();
+			attestation_matrix[attester_pos] = att_vec;
+		}
+
+		println!("Attestation matrix: {:#?}", attestation_matrix);
+
 		// Create EigenTrustSet
 		let mut eigen_trust_set =
 			EigenTrustSet::<MAX_NEIGHBOURS, NUM_ITERATIONS, INITIAL_SCORE>::new();
 
-		// Add members to set
-		let participants: Vec<Scalar> =
-			participants_set.iter().map(|address| scalar_from_address(address).unwrap()).collect();
+		// Create set
+		for participant in participants.clone() {
+			let participant_fr = scalar_from_address(&participant).unwrap();
 
-		for participant in participants {
-			eigen_trust_set.add_member(participant);
-		}
-
-		// Update members opinions
-		// This could be done in the same step as getting the participant set
-		// Create attestation map
-		let mut attestation_map: HashMap<ECDSAPublicKey, Vec<SignedAttestation>> = HashMap::new();
-
-		for (signed_att, _) in attestations.iter() {
-			// Get signer ECDSA public key
-			let signer_pub_key = signed_att.recover_public_key().unwrap();
-
-			// Put attestation in new vector
-			let att_vec = vec![signed_att.clone()];
-
-			// If signer exist, append vector, if not, just add
-			if attestation_map.contains_key(&signer_pub_key) {
-				let mut attestation_vec = attestation_map.get(&signer_pub_key).unwrap().clone();
-				attestation_vec.extend(att_vec);
-				attestation_map.insert(signer_pub_key, attestation_vec);
-			} else {
-				attestation_map.insert(signer_pub_key, att_vec);
-			}
+			eigen_trust_set.add_member(participant_fr);
 		}
 
 		// Update opinions
-		for (signer_pub_key, att_vec) in attestation_map.iter() {
-			eigen_trust_set.update_op(signer_pub_key.clone(), att_vec.clone());
+		for i in 0..participants.len() {
+			// Get attestation vector
+			let att_vec = attestation_matrix[i].clone();
+
+			// Get ECDSA public key
+			let participant_pub_key = att_vec[i].recover_public_key().unwrap();
+
+			eigen_trust_set.update_op(participant_pub_key, att_vec);
 		}
 
 		// Calculate scores
@@ -231,8 +245,6 @@ impl Client {
 			.from_block(0);
 		let logs = &self.client.get_logs(&filter).await.unwrap();
 		let mut att_tuple: Vec<(SignedAttestation, Attestation)> = Vec::new();
-
-		println!("Indexed attestations: {}", logs.iter().len());
 
 		for log in logs.iter() {
 			let raw_log = RawLog::from((log.topics.clone(), log.data.to_vec()));
@@ -283,8 +295,7 @@ mod lib_tests {
 		Client, ClientConfig,
 	};
 	use eigen_trust_circuit::utils::read_bytes_data;
-	use ethers::utils::Anvil;
-	use ethers::{abi::Address, types::H256};
+	use ethers::{abi::Address, types::H256, utils::Anvil};
 
 	#[tokio::test]
 	async fn test_attest() {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -50,6 +50,7 @@ pub mod error;
 pub mod eth;
 pub mod utils;
 
+use crate::utils::create_csv_file;
 use att_station::{AttestationCreatedFilter, AttestationStation};
 use attestation::{att_data_from_signed_att, Attestation, AttestationPayload};
 use eigen_trust_circuit::dynamic_sets::ecdsa_native::{EigenTrustSet, SignedAttestation};
@@ -228,7 +229,11 @@ impl Client {
 		// Calculate scores
 		let scores = eigen_trust_set.converge();
 
-		println!("Scores: {:?}", scores);
+		// Store scores
+		let formatted_scores: Vec<Vec<u8>> =
+			scores.iter().map(|&x| x.to_bytes().to_vec()).collect();
+
+		create_csv_file("scores", &formatted_scores).unwrap();
 
 		Ok(())
 	}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -72,10 +72,13 @@ async fn main() {
 			println!("EigenTrustVerifier deployed at {:?}", verifier_address);
 		},
 		Mode::Proof => {
-			println!("Calculating Proof...\n");
+			println!("Not implemented yet.");
+		},
+		Mode::Scores => {
+			println!("Calculating scores...\n");
 			let mut client = Client::new(config);
 			if let Err(e) = client.calculate_scores().await {
-				eprintln!("Error calculating proofs: {:?}", e);
+				eprintln!("Error calculating scores: {:?}", e);
 			}
 		},
 		Mode::Show => println!("Client config:\n{:#?}", config),

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -74,7 +74,7 @@ async fn main() {
 		Mode::Proof => {
 			println!("Calculating Proof...\n");
 			let mut client = Client::new(config);
-			if let Err(e) = client.calculate_proofs().await {
+			if let Err(e) = client.calculate_scores().await {
 				eprintln!("Error calculating proofs: {:?}", e);
 			}
 		},

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -1,4 +1,4 @@
-use csv::Reader as CsvReader;
+use csv::{Reader as CsvReader, Writer as CsvWriter};
 use serde::de::DeserializeOwned;
 use std::{
 	env,
@@ -34,4 +34,23 @@ pub fn read_csv_data<T: DeserializeOwned>(file_name: &str) -> Result<Vec<T>, Err
 		records.push(record);
 	}
 	Ok(records)
+}
+
+/// Creates new CSV file in the given path and stores the provided data
+pub fn create_csv_file<T, U>(filename: &str, content: T) -> Result<(), &'static str>
+where
+	T: IntoIterator<Item = U>,
+	U: AsRef<[u8]>,
+{
+	let path = format!("../data/{}.csv", filename);
+
+	let mut writer = CsvWriter::from_path(&path).map_err(|_| "Failed to open file")?;
+
+	// Write content
+	writer.write_record(content).map_err(|_| "Failed to write record")?;
+
+	// Flush buffer
+	writer.flush().map_err(|_| "Failed to flush buffer")?;
+
+	Ok(())
 }


### PR DESCRIPTION
# Related Issues

- Resolves #245 

# Description

This PR integrates the `calculate_scores` function into the client code. It operates by retrieving all attestation data and formatting it for the creation of an EigenTrustSet. The set computes the global trust scores and once this computation is complete, the `calculate_scores` function exports these results into a CSV file.

# Changes

- Refactor `recover_ethereum_address_from_pk` in the circuit
- Refactor `get_attestations`
- Fix pub_key hashing in the circuit (remove prefix)
- Multiple fixes related to endianness and types for attestation data
- Add and fix tests
- Implement `calculate_scores()`
- Implement `create_csv_file()`
- Add `scores` cli command
- Fix readme for new cli message format (optional 32-byte hex string)