### PR TITLE
docs(client): add missing docs and rustc lint rule

### DIFF
--- a/client/src/att_station.rs
+++ b/client/src/att_station.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #![allow(clippy::enum_variant_names)]
 #![allow(dead_code)]
 #![allow(clippy::type_complexity)]

--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -1,3 +1,8 @@
+//! # Attestation Module.
+//!
+//! This module deals with all attestations and AttestationStation related
+//! data types and functionalities.
+
 use crate::{
 	att_station::AttestationData as ContractAttestationData,
 	eth::{address_from_public_key, scalar_from_address},
@@ -9,12 +14,12 @@ use eigen_trust_circuit::{
 use ethers::types::{Address, H256};
 use secp256k1::ecdsa::{RecoverableSignature, RecoveryId};
 
-/// Domain prefix length
-pub const DOMAIN_PREFIX_LEN: usize = 12;
-/// Domain prefix
+/// Domain prefix.
 pub const DOMAIN_PREFIX: [u8; DOMAIN_PREFIX_LEN] = *b"eigen_trust_";
+/// Domain prefix length.
+pub const DOMAIN_PREFIX_LEN: usize = 12;
 
-/// Attestation struct
+/// Attestation struct.
 #[derive(Clone, Debug)]
 pub struct Attestation {
 	/// Ethereum address of peer being rated
@@ -28,12 +33,12 @@ pub struct Attestation {
 }
 
 impl Attestation {
-	/// Construct a new attestation struct
+	/// Constructs a new attestation struct.
 	pub fn new(about: Address, key: H256, value: u8, message: Option<H256>) -> Self {
 		Self { about, key, value, message: message.unwrap_or(H256::from([0u8; 32])) }
 	}
 
-	/// Convert to scalar representation
+	/// Converts the attestation to the scalar representation.
 	pub fn to_attestation_fr(&self) -> Result<AttestationFr, &'static str> {
 		// About
 		let about = scalar_from_address(&self.about)?;
@@ -66,7 +71,7 @@ impl Attestation {
 	}
 }
 
-/// Attestation raw data payload
+/// Attestation raw data payload.
 #[derive(Clone, Debug, PartialEq)]
 pub struct AttestationPayload {
 	sig_r: [u8; 32],
@@ -77,7 +82,7 @@ pub struct AttestationPayload {
 }
 
 impl AttestationPayload {
-	/// Convert a vector of bytes into the struct
+	/// Converts a vector of bytes into the struct.
 	pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, &'static str> {
 		if bytes.len() != 98 {
 			return Err("Input bytes vector should be of length 98");
@@ -96,7 +101,7 @@ impl AttestationPayload {
 		Ok(Self { sig_r, sig_s, rec_id, value, message })
 	}
 
-	/// Create AttestationPayload from SignedAttestation
+	/// Creates an AttestationPayload from a SignedAttestation.
 	pub fn from_signed_attestation(
 		signed_attestation: &SignedAttestation,
 	) -> Result<Self, &'static str> {
@@ -118,7 +123,7 @@ impl AttestationPayload {
 		Ok(Self { sig_r, sig_s, rec_id, value, message })
 	}
 
-	/// Convert the struct into a vector of bytes
+	/// Converts the struct into a vector of bytes.
 	pub fn to_bytes(&self) -> Vec<u8> {
 		let mut bytes = Vec::with_capacity(98);
 
@@ -131,7 +136,7 @@ impl AttestationPayload {
 		bytes
 	}
 
-	/// Get the ECDSA recoverable signature
+	/// Gets the ECDSA recoverable signature.
 	pub fn get_signature(&self) -> RecoverableSignature {
 		let concat_sig = [self.sig_r, self.sig_s].concat();
 		let recovery_id = RecoveryId::from_i32(i32::from(self.rec_id)).unwrap();
@@ -139,18 +144,18 @@ impl AttestationPayload {
 		RecoverableSignature::from_compact(concat_sig.as_slice(), recovery_id).unwrap()
 	}
 
-	/// Get the value
+	/// Gets the attestation value.
 	pub fn get_value(&self) -> u8 {
 		self.value
 	}
 
-	/// Get the message
+	/// Gets the attestation message.
 	pub fn get_message(&self) -> [u8; 32] {
 		self.message
 	}
 }
 
-/// Recover the signing Ethereum address from a signed attestation
+/// Recovers the signing Ethereum address from a signed attestation.
 pub fn address_from_signed_att(
 	signed_attestation: &SignedAttestation,
 ) -> Result<Address, &'static str> {
@@ -161,8 +166,8 @@ pub fn address_from_signed_att(
 	address_from_public_key(&public_key)
 }
 
-/// Construct the contract attestation data from a signed attestation
-/// The return of this function is the actual data stored on the contract
+/// Constructs the contract attestation data from a signed attestation.
+/// The return of this function is the actual data stored on the contract.
 pub fn att_data_from_signed_att(
 	signed_attestation: &SignedAttestation,
 ) -> Result<ContractAttestationData, &'static str> {

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -1,3 +1,7 @@
+//! # CLI Module.
+//!
+//! This module contains all CLI related data handling and conversions.
+
 use crate::ClientConfig;
 use clap::{Args, Parser, Subcommand};
 use eigen_trust_circuit::utils::write_json_data;
@@ -16,45 +20,45 @@ pub struct Cli {
 	pub mode: Mode,
 }
 
-/// Commands
+/// CLI commands.
 #[derive(Subcommand)]
 pub enum Mode {
-	/// Submit an attestation. Requires 'AttestData'
+	/// Submit an attestation. Requires 'AttestData'.
 	Attest(AttestData),
-	/// Compile the contracts
+	/// Compile the contracts.
 	Compile,
-	/// Deploy the contracts
+	/// Deploy the contracts.
 	Deploy,
-	/// Generate the proofs
+	/// Generate the proofs.
 	Proof,
-	/// Calculate the global scores
+	/// Calculate the global scores.
 	Scores,
-	/// Display the current client configuration
+	/// Display the current client configuration.
 	Show,
-	/// Update the client configuration. Requires 'UpdateData'
+	/// Update the client configuration. Requires 'UpdateData'.
 	Update(UpdateData),
-	/// Verify the proofs
+	/// Verify the proofs.
 	Verify,
 }
 
-/// Configuration update subcommand input
+/// Configuration update subcommand input.
 #[derive(Args, Debug)]
 pub struct UpdateData {
-	/// Address of the AttestationStation contract (20-byte ethereum address)
+	/// AttestationStation contract address (20-byte ethereum address).
 	#[clap(long = "as-address")]
 	as_address: Option<String>,
-	/// Domain id (20-byte hex string)
+	/// Attestation domain identifier (20-byte hex string).
 	#[clap(long = "domain")]
 	domain: Option<String>,
-	/// URL of the Ethereum node to connect to
+	/// Ethereum node URL.
 	#[clap(long = "node")]
 	node_url: Option<String>,
-	/// Address of the Verifier contract (20-byte ethereum address)
+	/// EigenTrustVerifier contract address (20-byte ethereum address).
 	#[clap(long = "verifier")]
 	verifier_address: Option<String>,
 }
 
-/// Handle the CLI project configuration update
+/// Handles the CLI project configuration update.
 pub fn handle_update(config: &mut ClientConfig, data: UpdateData) -> Result<(), &'static str> {
 	if let Some(as_address) = data.as_address {
 		config.as_address =
@@ -80,22 +84,22 @@ pub fn handle_update(config: &mut ClientConfig, data: UpdateData) -> Result<(), 
 	write_json_data(config, "client-config").map_err(|_| "Failed to write config data.")
 }
 
-/// Attestation subcommand input
+/// Attestation subcommand input.
 #[derive(Args, Debug)]
 pub struct AttestData {
-	/// Attested address (20-byte ethereum address)
+	/// Attested address (20-byte ethereum address).
 	#[clap(long = "to")]
 	address: Option<String>,
-	/// Given score (0-255)
+	/// Given score (0-255).
 	#[clap(long = "score")]
 	score: Option<String>,
-	/// Attestation message (hex-encoded)
+	/// Attestation message (32-byte hex string).
 	#[clap(long = "message")]
 	message: Option<String>,
 }
 
 impl AttestData {
-	/// Converts `AttestData` to `Attestation`
+	/// Converts `AttestData` to `Attestation`.
 	pub fn to_attestation(&self, config: &ClientConfig) -> Result<Attestation, &'static str> {
 		// Parse Address
 		let parsed_address: Address = self

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -1,3 +1,7 @@
+//! # Error Module.
+//!
+//! This module features the `EigenError` enum for error handling throughout the project.
+
 use serde::ser::StdError;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 

--- a/client/src/eth.rs
+++ b/client/src/eth.rs
@@ -1,7 +1,8 @@
-/// Ethereum Utility Module
-///
-/// This module provides types and functionalities for Ethereum blockchain interactions.
-use crate::ClientSigner;
+//! # Ethereum Module.
+//!
+//! This module provides types and functionalities for general ethereum interactions.
+
+use crate::{eth::bindings::AttestationStation, ClientSigner};
 use eigen_trust_circuit::{
 	dynamic_sets::native::ECDSAPublicKey,
 	halo2::halo2curves::bn256::Fr as Scalar,
@@ -11,7 +12,7 @@ use eigen_trust_circuit::{
 };
 use ethers::{
 	abi::Address,
-	prelude::{abigen, k256::ecdsa::SigningKey, Abigen, ContractError},
+	prelude::{k256::ecdsa::SigningKey, Abigen, ContractError},
 	providers::Middleware,
 	signers::coins_bip39::{English, Mnemonic},
 	solc::{artifacts::ContractBytecode, Solc},
@@ -25,16 +26,20 @@ use std::{
 	sync::Arc,
 };
 
-// Generate contract bindings
-abigen!(AttestationStation, "../data/AttestationStation.json");
+/// The contract bindings module.
+/// This is a workaround for the `abigen` macro not supporting doc comments as attributes.
+pub mod bindings {
+	#![allow(missing_docs)]
+	ethers::prelude::abigen!(AttestationStation, "../data/AttestationStation.json");
+}
 
-/// Deploys the AttestationStation contract
+/// Deploys the AttestationStation contract.
 pub async fn deploy_as(signer: Arc<ClientSigner>) -> Result<Address, ContractError<ClientSigner>> {
 	let contract = AttestationStation::deploy(signer, ())?.send().await?;
 	Ok(contract.address())
 }
 
-/// Deploys the EtVerifier contract
+/// Deploys the EtVerifier contract.
 pub async fn deploy_verifier(
 	signer: Arc<ClientSigner>, contract_bytes: Vec<u8>,
 ) -> Result<Address, ContractError<ClientSigner>> {
@@ -46,7 +51,7 @@ pub async fn deploy_verifier(
 	Ok(rec.contract_address.unwrap())
 }
 
-/// Calls the EtVerifier contract
+/// Calls the EtVerifier contract.
 pub async fn call_verifier(
 	signer: Arc<ClientSigner>, verifier_address: Address, proof: NativeProof,
 ) {
@@ -57,7 +62,7 @@ pub async fn call_verifier(
 	println!("{:#?}", res);
 }
 
-/// Compile the solidity contracts
+/// Compiles the solidity contracts.
 pub fn compile_sol_contract() {
 	let curr_dir = env::current_dir().unwrap();
 	let contracts_dir = curr_dir.join("../data/");
@@ -80,7 +85,7 @@ pub fn compile_sol_contract() {
 	}
 }
 
-/// Compile the yul contracts
+/// Compiles the yul contracts.
 pub fn compile_yul_contracts() {
 	let curr_dir = env::current_dir().unwrap();
 	let contracts_dir = curr_dir.join("../data/");
@@ -100,7 +105,7 @@ pub fn compile_yul_contracts() {
 	}
 }
 
-/// Returns a vector of ECDSA private keys derived from the given mnemonic phrase
+/// Returns a vector of ECDSA private keys derived from the given mnemonic phrase.
 pub fn ecdsa_secret_from_mnemonic(
 	mnemonic: &str, count: u32,
 ) -> Result<Vec<SecretKey>, &'static str> {
@@ -129,7 +134,7 @@ pub fn ecdsa_secret_from_mnemonic(
 	Ok(keys)
 }
 
-/// Construct an Ethereum address for the given ECDSA public key
+/// Constructs an Ethereum address for the given ECDSA public key.
 pub fn address_from_public_key(pub_key: &ECDSAPublicKey) -> Result<Address, &'static str> {
 	let pub_key_bytes: [u8; 65] = pub_key.serialize_uncompressed();
 
@@ -142,7 +147,7 @@ pub fn address_from_public_key(pub_key: &ECDSAPublicKey) -> Result<Address, &'st
 	Ok(Address::from_slice(address_bytes))
 }
 
-/// Construct a Scalar from the given Ethereum address
+/// Constructs a Scalar from the given Ethereum address.
 pub fn scalar_from_address(address: &Address) -> Result<Scalar, &'static str> {
 	let mut address_fixed = address.to_fixed_bytes();
 	address_fixed.reverse();

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -4,6 +4,7 @@
 //! features.
 //!
 //! ## Main characteristics:
+//!
 //! **Self-policing** - the shared ethics of the user population is defined and
 //! enforced by the peers themselves and not by some central authority.
 //!
@@ -16,28 +17,29 @@
 //! resistant to malicious collectives.
 //!
 //! ## Implementation
+//!
 //! The library is implemented according to the original [Eigen Trust paper](http://ilpubs.stanford.edu:8090/562/1/2002-56.pdf).
-//! It is developed under the Ethereum Foundation grant.
+//! It is developed under an Ethereum Foundation grant.
 
 // Rustc
 #![warn(trivial_casts)]
 #![deny(
-	absolute_paths_not_starting_with_crate, deprecated, future_incompatible, unreachable_code,
-	unreachable_patterns
+	absolute_paths_not_starting_with_crate, deprecated, future_incompatible, missing_docs,
+	nonstandard_style, unreachable_code, unreachable_patterns
 )]
 #![forbid(unsafe_code)]
 #![deny(
-// 	// Complexity
+	// Complexity
  	clippy::unnecessary_cast,
 	clippy::needless_question_mark,
-// 	// Pedantic
+	// Pedantic
  	clippy::cast_lossless,
  	clippy::cast_possible_wrap,
-// 	// Perf
+	// Perf
 	clippy::redundant_clone,
-// 	// Restriction
+	// Restriction
  	clippy::panic,
-// 	// Style
+	// Style
  	clippy::let_and_return,
  	clippy::needless_borrow
 )]
@@ -72,32 +74,36 @@ use secp256k1::{ecdsa::RecoverableSignature, Message, SecretKey, SECP256K1};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, sync::Arc};
 
-/// Max amount of participants
+/// Max amount of participants.
 const MAX_NEIGHBOURS: usize = 4;
-/// Number of iterations to run the eigen trust algorithm
+/// Number of iterations to run the eigen trust algorithm.
 const NUM_ITERATIONS: usize = 10;
-/// Initial score for each participant before the algorithms is run
+/// Initial score for each participant before the algorithms is run.
 const INITIAL_SCORE: u128 = 1000;
 
-/// Client configuration
+/// Client configuration settings.
 #[derive(Serialize, Deserialize, Debug, EthDisplay, Clone)]
 pub struct ClientConfig {
+	/// AttestationStation contract address.
 	pub as_address: String,
+	/// Attestation domain identifier.
 	pub domain: String,
+	/// Ethereum node URL.
 	pub node_url: String,
+	/// EigenTrustVerifier contract address.
 	pub verifier_address: String,
 }
 
-/// Local environment configuration
+/// Local environment configuration.
 struct LocalEnv {
 	mnemonic: String,
 	_bandada_api_key: String,
 }
 
-/// Signer type alias
+/// Signer type alias.
 pub type ClientSigner = SignerMiddleware<Provider<Http>, LocalWallet>;
 
-/// Client
+/// Client struct.
 pub struct Client {
 	signer: Arc<ClientSigner>,
 	config: ClientConfig,
@@ -105,7 +111,7 @@ pub struct Client {
 }
 
 impl Client {
-	/// Creates new client
+	/// Creates a new Client instance.
 	pub fn new(config: ClientConfig) -> Self {
 		// Load environment config
 		let env = Self::get_env();
@@ -129,7 +135,7 @@ impl Client {
 		Self { signer: shared_signer, config, env }
 	}
 
-	/// Submit an attestation to the attestation station
+	/// Submits an attestation to the attestation station.
 	pub async fn attest(&self, attestation: Attestation) -> Result<(), EigenError> {
 		let ctx = SECP256K1;
 		let secret_keys: Vec<SecretKey> =
@@ -173,7 +179,7 @@ impl Client {
 		Ok(())
 	}
 
-	/// Calculate scores
+	/// Calculates the EigenTrust global scores.
 	pub async fn calculate_scores(&mut self) -> Result<(), EigenError> {
 		// Get attestations
 		let attestations = self.get_attestations().await?;
@@ -283,7 +289,7 @@ impl Client {
 		Ok(())
 	}
 
-	/// Get the attestations from the contract
+	/// Gets the attestations from the contract.
 	pub async fn get_attestations(
 		&self,
 	) -> Result<Vec<(SignedAttestation, Attestation)>, EigenError> {
@@ -321,18 +327,18 @@ impl Client {
 		Ok(att_tuple)
 	}
 
-	/// Verifies last generated proof
+	/// Verifies last generated proof.
 	pub async fn verify(&self) -> Result<(), EigenError> {
 		// TODO: Verify proof
 		Ok(())
 	}
 
-	/// Gets signer
+	/// Gets signer.
 	pub fn get_signer(&self) -> Arc<ClientSigner> {
 		self.signer.clone()
 	}
 
-	/// Gets local environment variables
+	/// Gets local environment variables.
 	fn get_env() -> LocalEnv {
 		// Load local .env file
 		dotenv().ok();

--- a/client/src/utils.rs
+++ b/client/src/utils.rs
@@ -1,3 +1,7 @@
+//! # Utils Module.
+//!
+//! This module contains generic utility functions.
+
 use csv::{Reader as CsvReader, Writer as CsvWriter};
 use serde::de::DeserializeOwned;
 use std::{
@@ -7,7 +11,7 @@ use std::{
 	path::Path,
 };
 
-/// Reads the json file and deserialize it into the provided type
+/// Reads the json file and deserialize it into the provided type.
 pub fn read_csv_file<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<Vec<T>, Error> {
 	let path = path.as_ref();
 	let file = File::open(path)?;
@@ -21,7 +25,7 @@ pub fn read_csv_file<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<Vec<
 	Ok(records)
 }
 
-/// Reads the json file and deserialize it into the provided type
+/// Reads the json file and deserialize it into the provided type.
 pub fn read_csv_data<T: DeserializeOwned>(file_name: &str) -> Result<Vec<T>, Error> {
 	let current_dir = env::current_dir().unwrap();
 	let path = current_dir.join(format!("../data/{}.csv", file_name));
@@ -36,7 +40,7 @@ pub fn read_csv_data<T: DeserializeOwned>(file_name: &str) -> Result<Vec<T>, Err
 	Ok(records)
 }
 
-/// Creates new CSV file in the given path and stores the provided data
+/// Creates new CSV file in the given path and stores the provided data.
 pub fn create_csv_file<T, U, V>(filename: &str, content: T) -> Result<(), &'static str>
 where
 	T: IntoIterator<Item = U>,


### PR DESCRIPTION
# Description

This PR adds the missing documentation for the client module and enables the rustc `#![deny(missing_docs)]` rule.

It also features updates on multiple doc comments across the module to keep a similar format.

## Related Issues

- Resolves #266

## Changes

- Add `missing_docs` rule to the client module.
- Implement missing documentation in the client.
- Add workaround for the `abigen` macro not being able to receive doc comments as input.
