### PR TITLE
feat(circuit): update halo2 circuit chip gates to utilise all columns

### DIFF
--- a/circuit/src/circuit.rs
+++ b/circuit/src/circuit.rs
@@ -541,7 +541,7 @@ mod test {
 			ops,
 		);
 
-		let k = 14;
+		let k = 13;
 		let prover = match MockProver::<Scalar>::run(k, &et, vec![res.to_vec()]) {
 			Ok(prover) => prover,
 			Err(e) => panic!("{}", e),
@@ -609,7 +609,7 @@ mod test {
 			ops,
 		);
 
-		let k = 14;
+		let k = 13;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
 		let res = prove_and_verify::<Bn256, _, _>(params, et, &[&res], rng).unwrap();
@@ -676,7 +676,7 @@ mod test {
 			ops,
 		);
 
-		let k = 14;
+		let k = 13;
 		let params = read_params(k);
 		let pk = gen_pk(&params, &et);
 		let deployment_code = gen_evm_verifier(&params, pk.get_vk(), vec![NUM_NEIGHBOURS]);

--- a/circuit/src/eddsa/mod.rs
+++ b/circuit/src/eddsa/mod.rs
@@ -325,7 +325,7 @@ mod test {
 		let sig = sign(&sk, &pk, m);
 		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m);
 
-		let k = 11;
+		let k = 10;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}
@@ -348,7 +348,7 @@ mod test {
 		sig.big_r = b8.mul_scalar(different_r).affine();
 		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m);
 
-		let k = 11;
+		let k = 10;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 		assert!(prover.verify().is_err());
 	}
@@ -366,7 +366,7 @@ mod test {
 		sig.s = sig.s.add(&Fr::from(1));
 		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m);
 
-		let k = 11;
+		let k = 10;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 		assert!(prover.verify().is_err());
 	}
@@ -385,7 +385,7 @@ mod test {
 		let m = Fr::from_str_vartime("123456789012345678901234567890").unwrap();
 		let sig = sign(&sk1, &pk1, m);
 		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk2.0.x, pk2.0.y, m);
-		let k = 11;
+		let k = 10;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 		assert!(prover.verify().is_err());
 	}
@@ -404,7 +404,7 @@ mod test {
 		let sig = sign(&sk, &pk, m1);
 		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m2);
 
-		let k = 11;
+		let k = 10;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 
 		assert!(prover.verify().is_err());
@@ -421,7 +421,7 @@ mod test {
 		let sig = sign(&sk, &pk, m);
 		let circuit = TestCircuit::new(sig.big_r.x, sig.big_r.y, sig.s, pk.0.x, pk.0.y, m);
 
-		let k = 11;
+		let k = 10;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
 		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[&[]], rng).unwrap();

--- a/circuit/src/edwards/mod.rs
+++ b/circuit/src/edwards/mod.rs
@@ -553,7 +553,7 @@ mod test {
 		let r = UnassignedPoint::new(r.x, r.y, r.z);
 		let circuit = AddTestCircuit::new(e, r);
 
-		let k = 6;
+		let k = 4;
 		let pub_ins = vec![x_res, y_res, z_res];
 		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -571,7 +571,7 @@ mod test {
 		let r = UnassignedPoint::new(r.x, r.y, r.z);
 		let circuit = AddTestCircuit::new(e, r);
 
-		let k = 10;
+		let k = 8;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
 		let pub_ins = [x_res, y_res, z_res];
@@ -635,7 +635,7 @@ mod test {
 		let r = UnassignedPoint::new(r.x, r.y, r.z);
 		let circuit = IntoAffineTestCircuit::new(r);
 
-		let k = 6;
+		let k = 4;
 		let pub_ins = vec![r_affine.x, r_affine.y];
 		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -650,7 +650,7 @@ mod test {
 		let r = UnassignedPoint::new(r.x, r.y, r.z);
 		let circuit = IntoAffineTestCircuit::new(r);
 
-		let k = 8;
+		let k = 6;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
 		let pub_ins = vec![r_affine.x, r_affine.y];
@@ -737,7 +737,7 @@ mod test {
 		let r = UnassignedPoint::new(r.x, r.y, r.z);
 		let circuit = MulScalarTestCircuit::new(r, scalar);
 
-		let k = 10;
+		let k = 9;
 		let pub_ins = vec![res.x, res.y, res.z];
 		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -755,7 +755,7 @@ mod test {
 		let r = UnassignedPoint::new(r.x, r.y, r.z);
 		let circuit = MulScalarTestCircuit::new(r, scalar);
 
-		let k = 10;
+		let k = 9;
 		let pub_ins = vec![res.x, res.y, res.z];
 		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -773,7 +773,7 @@ mod test {
 		let r = UnassignedPoint::new(r.x, r.y, r.z);
 		let circuit = MulScalarTestCircuit::new(r, scalar);
 
-		let k = 10;
+		let k = 9;
 		let pub_ins = vec![res.x, res.y, res.z];
 		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -790,7 +790,7 @@ mod test {
 		let r = UnassignedPoint::new(r.x, r.y, r.z);
 		let circuit = MulScalarTestCircuit::new(r, scalar);
 
-		let k = 10;
+		let k = 9;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
 		let pub_ins = [res.x, res.y, res.z];

--- a/circuit/src/edwards/mod.rs
+++ b/circuit/src/edwards/mod.rs
@@ -87,9 +87,9 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for PointAddChip<F, P> {
 			let e_y_exp = v_cells.query_advice(common.advice[4], Rotation::cur());
 			let e_z_exp = v_cells.query_advice(common.advice[5], Rotation::cur());
 
-			let r_x_next_exp = v_cells.query_advice(common.advice[0], Rotation::next());
-			let r_y_next_exp = v_cells.query_advice(common.advice[1], Rotation::next());
-			let r_z_next_exp = v_cells.query_advice(common.advice[2], Rotation::next());
+			let r_x_next_exp = v_cells.query_advice(common.advice[6], Rotation::cur());
+			let r_y_next_exp = v_cells.query_advice(common.advice[7], Rotation::cur());
+			let r_z_next_exp = v_cells.query_advice(common.advice[8], Rotation::cur());
 
 			let (r_x3, r_y3, r_z3) =
 				P::add_exp(r_x_exp, r_y_exp, r_z_exp, e_x_exp, e_y_exp, e_z_exp);
@@ -131,10 +131,9 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for PointAddChip<F, P> {
 					e_z.value().cloned(),
 				);
 
-				ctx.next();
-				let r_x_res = ctx.assign_advice(common.advice[0], r_x3)?;
-				let r_y_res = ctx.assign_advice(common.advice[1], r_y3)?;
-				let r_z_res = ctx.assign_advice(common.advice[2], r_z3)?;
+				let r_x_res = ctx.assign_advice(common.advice[6], r_x3)?;
+				let r_y_res = ctx.assign_advice(common.advice[7], r_y3)?;
+				let r_z_res = ctx.assign_advice(common.advice[8], r_z3)?;
 
 				let res = AssignedPoint::new(r_x_res, r_y_res, r_z_res);
 

--- a/circuit/src/edwards/mod.rs
+++ b/circuit/src/edwards/mod.rs
@@ -240,24 +240,28 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for ScalarMulChip<F, P> {
 		let selector = meta.selector();
 
 		meta.create_gate("scalar_mul", |v_cells| {
+			//
+			// IMPORTANT: For the maximal usage of CommonConfig columns(20 advice + 10 fixed),
+			//			  we use the advice column 13 - 19. (14th ~ 20th)
+			//
 			let s_exp = v_cells.query_selector(selector);
-			let bit_exp = v_cells.query_advice(common.advice[0], Rotation::cur());
+			let bit_exp = v_cells.query_advice(common.advice[13], Rotation::cur());
 
-			let r_x_exp = v_cells.query_advice(common.advice[1], Rotation::cur());
-			let r_y_exp = v_cells.query_advice(common.advice[2], Rotation::cur());
-			let r_z_exp = v_cells.query_advice(common.advice[3], Rotation::cur());
+			let r_x_exp = v_cells.query_advice(common.advice[14], Rotation::cur());
+			let r_y_exp = v_cells.query_advice(common.advice[15], Rotation::cur());
+			let r_z_exp = v_cells.query_advice(common.advice[16], Rotation::cur());
 
-			let e_x_exp = v_cells.query_advice(common.advice[4], Rotation::cur());
-			let e_y_exp = v_cells.query_advice(common.advice[5], Rotation::cur());
-			let e_z_exp = v_cells.query_advice(common.advice[6], Rotation::cur());
+			let e_x_exp = v_cells.query_advice(common.advice[17], Rotation::cur());
+			let e_y_exp = v_cells.query_advice(common.advice[18], Rotation::cur());
+			let e_z_exp = v_cells.query_advice(common.advice[19], Rotation::cur());
 
-			let r_x_next_exp = v_cells.query_advice(common.advice[1], Rotation::next());
-			let r_y_next_exp = v_cells.query_advice(common.advice[2], Rotation::next());
-			let r_z_next_exp = v_cells.query_advice(common.advice[3], Rotation::next());
+			let r_x_next_exp = v_cells.query_advice(common.advice[14], Rotation::next());
+			let r_y_next_exp = v_cells.query_advice(common.advice[15], Rotation::next());
+			let r_z_next_exp = v_cells.query_advice(common.advice[16], Rotation::next());
 
-			let e_x_next_exp = v_cells.query_advice(common.advice[4], Rotation::next());
-			let e_y_next_exp = v_cells.query_advice(common.advice[5], Rotation::next());
-			let e_z_next_exp = v_cells.query_advice(common.advice[6], Rotation::next());
+			let e_x_next_exp = v_cells.query_advice(common.advice[17], Rotation::next());
+			let e_y_next_exp = v_cells.query_advice(common.advice[18], Rotation::next());
+			let e_z_next_exp = v_cells.query_advice(common.advice[19], Rotation::next());
 
 			// TODO: Replace with special double_add operation
 			let (r_x3, r_y3, r_z3) = P::add_exp(
@@ -300,17 +304,17 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for ScalarMulChip<F, P> {
 			|| "scalar_mul",
 			|region: Region<'_, F>| {
 				let mut ctx = RegionCtx::new(region, 0);
-				let mut r_x = ctx.assign_from_constant(common.advice[1], F::ZERO)?;
-				let mut r_y = ctx.assign_from_constant(common.advice[2], F::ONE)?;
-				let mut r_z = ctx.assign_from_constant(common.advice[3], F::ONE)?;
-				let mut e_x = ctx.copy_assign(common.advice[4], self.e.x.clone())?;
-				let mut e_y = ctx.copy_assign(common.advice[5], self.e.y.clone())?;
-				let mut e_z = ctx.copy_assign(common.advice[6], self.e.z.clone())?;
+				let mut r_x = ctx.assign_from_constant(common.advice[14], F::ZERO)?;
+				let mut r_y = ctx.assign_from_constant(common.advice[15], F::ONE)?;
+				let mut r_z = ctx.assign_from_constant(common.advice[16], F::ONE)?;
+				let mut e_x = ctx.copy_assign(common.advice[17], self.e.x.clone())?;
+				let mut e_y = ctx.copy_assign(common.advice[18], self.e.y.clone())?;
+				let mut e_z = ctx.copy_assign(common.advice[19], self.e.z.clone())?;
 
 				// Double and add operation.
 				for i in 0..self.value_bits.len() {
 					ctx.enable(*selector)?;
-					ctx.copy_assign(common.advice[0], self.value_bits[i].clone())?;
+					ctx.copy_assign(common.advice[13], self.value_bits[i].clone())?;
 
 					// Add `r` and `e`.
 					let (r_x3, r_y3, r_z3) = P::add_value(
@@ -342,12 +346,12 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for ScalarMulChip<F, P> {
 					};
 
 					ctx.next();
-					r_x = ctx.assign_advice(common.advice[1], r_x_next)?;
-					r_y = ctx.assign_advice(common.advice[2], r_y_next)?;
-					r_z = ctx.assign_advice(common.advice[3], r_z_next)?;
-					e_x = ctx.assign_advice(common.advice[4], e_x3)?;
-					e_y = ctx.assign_advice(common.advice[5], e_y3)?;
-					e_z = ctx.assign_advice(common.advice[6], e_z3)?;
+					r_x = ctx.assign_advice(common.advice[14], r_x_next)?;
+					r_y = ctx.assign_advice(common.advice[15], r_y_next)?;
+					r_z = ctx.assign_advice(common.advice[16], r_z_next)?;
+					e_x = ctx.assign_advice(common.advice[17], e_x3)?;
+					e_y = ctx.assign_advice(common.advice[18], e_y3)?;
+					e_z = ctx.assign_advice(common.advice[19], e_z3)?;
 				}
 
 				let res = AssignedPoint::new(r_x, r_y, r_z);

--- a/circuit/src/edwards/mod.rs
+++ b/circuit/src/edwards/mod.rs
@@ -240,28 +240,24 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for ScalarMulChip<F, P> {
 		let selector = meta.selector();
 
 		meta.create_gate("scalar_mul", |v_cells| {
-			//
-			// IMPORTANT: For the maximal usage of CommonConfig columns(20 advice + 10 fixed),
-			//			  we use the advice column 13 - 19. (14th ~ 20th)
-			//
 			let s_exp = v_cells.query_selector(selector);
-			let bit_exp = v_cells.query_advice(common.advice[13], Rotation::cur());
+			let bit_exp = v_cells.query_advice(common.advice[0], Rotation::cur());
 
-			let r_x_exp = v_cells.query_advice(common.advice[14], Rotation::cur());
-			let r_y_exp = v_cells.query_advice(common.advice[15], Rotation::cur());
-			let r_z_exp = v_cells.query_advice(common.advice[16], Rotation::cur());
+			let r_x_exp = v_cells.query_advice(common.advice[1], Rotation::cur());
+			let r_y_exp = v_cells.query_advice(common.advice[2], Rotation::cur());
+			let r_z_exp = v_cells.query_advice(common.advice[3], Rotation::cur());
 
-			let e_x_exp = v_cells.query_advice(common.advice[17], Rotation::cur());
-			let e_y_exp = v_cells.query_advice(common.advice[18], Rotation::cur());
-			let e_z_exp = v_cells.query_advice(common.advice[19], Rotation::cur());
+			let e_x_exp = v_cells.query_advice(common.advice[4], Rotation::cur());
+			let e_y_exp = v_cells.query_advice(common.advice[5], Rotation::cur());
+			let e_z_exp = v_cells.query_advice(common.advice[6], Rotation::cur());
 
-			let r_x_next_exp = v_cells.query_advice(common.advice[14], Rotation::next());
-			let r_y_next_exp = v_cells.query_advice(common.advice[15], Rotation::next());
-			let r_z_next_exp = v_cells.query_advice(common.advice[16], Rotation::next());
+			let r_x_next_exp = v_cells.query_advice(common.advice[1], Rotation::next());
+			let r_y_next_exp = v_cells.query_advice(common.advice[2], Rotation::next());
+			let r_z_next_exp = v_cells.query_advice(common.advice[3], Rotation::next());
 
-			let e_x_next_exp = v_cells.query_advice(common.advice[17], Rotation::next());
-			let e_y_next_exp = v_cells.query_advice(common.advice[18], Rotation::next());
-			let e_z_next_exp = v_cells.query_advice(common.advice[19], Rotation::next());
+			let e_x_next_exp = v_cells.query_advice(common.advice[4], Rotation::next());
+			let e_y_next_exp = v_cells.query_advice(common.advice[5], Rotation::next());
+			let e_z_next_exp = v_cells.query_advice(common.advice[6], Rotation::next());
 
 			// TODO: Replace with special double_add operation
 			let (r_x3, r_y3, r_z3) = P::add_exp(
@@ -304,17 +300,17 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for ScalarMulChip<F, P> {
 			|| "scalar_mul",
 			|region: Region<'_, F>| {
 				let mut ctx = RegionCtx::new(region, 0);
-				let mut r_x = ctx.assign_from_constant(common.advice[14], F::ZERO)?;
-				let mut r_y = ctx.assign_from_constant(common.advice[15], F::ONE)?;
-				let mut r_z = ctx.assign_from_constant(common.advice[16], F::ONE)?;
-				let mut e_x = ctx.copy_assign(common.advice[17], self.e.x.clone())?;
-				let mut e_y = ctx.copy_assign(common.advice[18], self.e.y.clone())?;
-				let mut e_z = ctx.copy_assign(common.advice[19], self.e.z.clone())?;
+				let mut r_x = ctx.assign_from_constant(common.advice[1], F::ZERO)?;
+				let mut r_y = ctx.assign_from_constant(common.advice[2], F::ONE)?;
+				let mut r_z = ctx.assign_from_constant(common.advice[3], F::ONE)?;
+				let mut e_x = ctx.copy_assign(common.advice[4], self.e.x.clone())?;
+				let mut e_y = ctx.copy_assign(common.advice[5], self.e.y.clone())?;
+				let mut e_z = ctx.copy_assign(common.advice[6], self.e.z.clone())?;
 
 				// Double and add operation.
 				for i in 0..self.value_bits.len() {
 					ctx.enable(*selector)?;
-					ctx.copy_assign(common.advice[13], self.value_bits[i].clone())?;
+					ctx.copy_assign(common.advice[0], self.value_bits[i].clone())?;
 
 					// Add `r` and `e`.
 					let (r_x3, r_y3, r_z3) = P::add_value(
@@ -346,12 +342,12 @@ impl<F: FieldExt, P: EdwardsParams<F>> Chip<F> for ScalarMulChip<F, P> {
 					};
 
 					ctx.next();
-					r_x = ctx.assign_advice(common.advice[14], r_x_next)?;
-					r_y = ctx.assign_advice(common.advice[15], r_y_next)?;
-					r_z = ctx.assign_advice(common.advice[16], r_z_next)?;
-					e_x = ctx.assign_advice(common.advice[17], e_x3)?;
-					e_y = ctx.assign_advice(common.advice[18], e_y3)?;
-					e_z = ctx.assign_advice(common.advice[19], e_z3)?;
+					r_x = ctx.assign_advice(common.advice[1], r_x_next)?;
+					r_y = ctx.assign_advice(common.advice[2], r_y_next)?;
+					r_z = ctx.assign_advice(common.advice[3], r_z_next)?;
+					e_x = ctx.assign_advice(common.advice[4], e_x3)?;
+					e_y = ctx.assign_advice(common.advice[5], e_y3)?;
+					e_z = ctx.assign_advice(common.advice[6], e_z3)?;
 				}
 
 				let res = AssignedPoint::new(r_x, r_y, r_z);

--- a/circuit/src/gadgets/bits2integer.rs
+++ b/circuit/src/gadgets/bits2integer.rs
@@ -176,7 +176,7 @@ mod test {
 		let numba = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(numba_big);
 
 		let circuit = TestCircuit::new(numba);
-		let k = 9;
+		let k = 8;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 
 		assert_eq!(prover.verify(), Ok(()));
@@ -192,7 +192,7 @@ mod test {
 		let numba = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(numba_big);
 
 		let circuit = TestCircuit::new(numba);
-		let k = 9;
+		let k = 8;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 
 		assert_eq!(prover.verify(), Ok(()));
@@ -203,7 +203,7 @@ mod test {
 		let numba_big = BigUint::from_str("3823613239503432837285398709123").unwrap();
 		let numba = Integer::<W, N, NUM_LIMBS, NUM_BITS, P>::new(numba_big);
 		let circuit = TestCircuit::new(numba);
-		let k = 9;
+		let k = 8;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
 		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[&[]], rng).unwrap();

--- a/circuit/src/gadgets/bits2num.rs
+++ b/circuit/src/gadgets/bits2num.rs
@@ -77,20 +77,20 @@ impl<F: FieldExt> Chip<F> for Bits2NumChip<F> {
 			//
 
 			// IMPORTANT: For the maximal usage of CommonConfig columns(20 advice + 10 fixed),
-			//			  we use the advice column 7 - 12. (8th ~ 13th)
+			//			  we use the advice column 10 - 15. (11th ~ 16th)
 
 			let one_exp = Expression::Constant(F::ONE);
 
-			let bit_i_exp = v_cells.query_advice(common.advice[7], Rotation::cur());
-			let e2_i_exp = v_cells.query_advice(common.advice[8], Rotation::cur());
-			let lc1_i_exp = v_cells.query_advice(common.advice[9], Rotation::cur());
+			let bit_i_exp = v_cells.query_advice(common.advice[10], Rotation::cur());
+			let e2_i_exp = v_cells.query_advice(common.advice[11], Rotation::cur());
+			let lc1_i_exp = v_cells.query_advice(common.advice[12], Rotation::cur());
 
-			let bit_i_1_exp = v_cells.query_advice(common.advice[10], Rotation::cur());
-			let e2_i_1_exp = v_cells.query_advice(common.advice[11], Rotation::cur());
-			let lc1_i_1_exp = v_cells.query_advice(common.advice[12], Rotation::cur());
+			let bit_i_1_exp = v_cells.query_advice(common.advice[13], Rotation::cur());
+			let e2_i_1_exp = v_cells.query_advice(common.advice[14], Rotation::cur());
+			let lc1_i_1_exp = v_cells.query_advice(common.advice[15], Rotation::cur());
 
-			let e2_next_exp = v_cells.query_advice(common.advice[8], Rotation::next());
-			let lc1_next_exp = v_cells.query_advice(common.advice[9], Rotation::next());
+			let e2_next_exp = v_cells.query_advice(common.advice[11], Rotation::next());
+			let lc1_next_exp = v_cells.query_advice(common.advice[12], Rotation::next());
 
 			let s_exp = v_cells.query_selector(selector);
 
@@ -130,8 +130,8 @@ impl<F: FieldExt> Chip<F> for Bits2NumChip<F> {
 			|| "bits2num",
 			|region: Region<'_, F>| {
 				let mut ctx = RegionCtx::new(region, 0);
-				let mut lc1 = ctx.assign_from_constant(common.advice[9], F::ZERO)?;
-				let mut e2 = ctx.assign_from_constant(common.advice[8], F::ONE)?;
+				let mut lc1 = ctx.assign_from_constant(common.advice[12], F::ZERO)?;
+				let mut e2 = ctx.assign_from_constant(common.advice[11], F::ONE)?;
 
 				let mut res_bits = Vec::new();
 
@@ -145,16 +145,16 @@ impl<F: FieldExt> Chip<F> for Bits2NumChip<F> {
 					ctx.enable(*selector)?;
 
 					// assign `bits[i]` & compute next values
-					let bit_i = ctx.assign_advice(common.advice[7], input_bits[i])?;
+					let bit_i = ctx.assign_advice(common.advice[10], input_bits[i])?;
 
 					let lc1_i_1 =
 						lc1.value().cloned() + bit_i.value().cloned() * e2.value().cloned();
 					let e2_i_1 = e2.value().cloned() + e2.value();
 
 					// assign `bits[i + 1]` & compute next values
-					let bit_i_1 = ctx.assign_advice(common.advice[10], input_bits[i + 1])?;
-					let e2_i_1 = ctx.assign_advice(common.advice[11], e2_i_1)?;
-					let lc1_1 = ctx.assign_advice(common.advice[12], lc1_i_1)?;
+					let bit_i_1 = ctx.assign_advice(common.advice[13], input_bits[i + 1])?;
+					let e2_i_1 = ctx.assign_advice(common.advice[14], e2_i_1)?;
+					let lc1_1 = ctx.assign_advice(common.advice[15], lc1_i_1)?;
 
 					let lc1_next =
 						lc1_1.value().cloned() + bit_i_1.value().cloned() * e2_i_1.value().cloned();
@@ -164,8 +164,8 @@ impl<F: FieldExt> Chip<F> for Bits2NumChip<F> {
 					res_bits.push(bit_i_1.clone());
 
 					ctx.next();
-					e2 = ctx.assign_advice(common.advice[8], e2_next)?;
-					lc1 = ctx.assign_advice(common.advice[9], lc1_next)?;
+					e2 = ctx.assign_advice(common.advice[11], e2_next)?;
+					lc1 = ctx.assign_advice(common.advice[12], lc1_next)?;
 				}
 				ctx.constrain_equal(self.value.clone(), lc1)?;
 

--- a/circuit/src/gadgets/bits2num.rs
+++ b/circuit/src/gadgets/bits2num.rs
@@ -102,7 +102,7 @@ impl<F: FieldExt> Chip<F> for Bits2NumChip<F> {
 				// e2 + e2 == e2_next
 				// Starting from 1, doubling.
 				s_exp.clone() * ((e2_i_exp.clone() + e2_i_exp.clone()) - e2_i_1_exp.clone()),
-				s_exp.clone() * ((e2_i_1_exp.clone() + e2_i_1_exp.clone()) - e2_next_exp.clone()),
+				s_exp.clone() * ((e2_i_1_exp.clone() + e2_i_1_exp.clone()) - e2_next_exp),
 				// lc1 + bit * e2 == lc1_next
 				// If the bit is equal to 1, e2 will be added to the sum.
 				// Example:

--- a/circuit/src/gadgets/bits2num.rs
+++ b/circuit/src/gadgets/bits2num.rs
@@ -255,7 +255,7 @@ mod test {
 		let numba = Fr::from(1311768467294899695u64);
 
 		let circuit = TestCircuit::<256>::new(numba);
-		let k = 9;
+		let k = 8;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 
 		assert_eq!(prover.verify(), Ok(()));
@@ -267,7 +267,7 @@ mod test {
 		let numba = Fr::zero().sub(&Fr::one());
 
 		let circuit = TestCircuit::<256>::new(numba);
-		let k = 9;
+		let k = 8;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 
 		assert_eq!(prover.verify(), Ok(()));
@@ -277,7 +277,7 @@ mod test {
 	fn test_bits_to_num_big_plus() {
 		// Testing biggest value in the field + 1.
 		let circuit = TestCircuit::<256>::new(Fr::zero());
-		let k = 9;
+		let k = 8;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 
 		assert_eq!(prover.verify(), Ok(()));
@@ -287,7 +287,7 @@ mod test {
 	fn test_bits_to_num_zero_bits() {
 		// Testing zero as value with 0 bits.
 		let circuit = TestCircuit::<0>::new(Fr::zero());
-		let k = 9;
+		let k = 8;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 
 		assert_eq!(prover.verify(), Ok(()));
@@ -297,7 +297,7 @@ mod test {
 	fn test_bits_to_num_zero_value() {
 		// Testing zero as value with 254 bits.
 		let circuit = TestCircuit::<254>::new(Fr::zero());
-		let k = 9;
+		let k = 8;
 		let prover = MockProver::run(k, &circuit, vec![vec![]]).unwrap();
 
 		assert_eq!(prover.verify(), Ok(()));
@@ -307,7 +307,7 @@ mod test {
 	fn test_bits_to_num_production() {
 		let numba = Fr::from(1311768467294899695u64);
 		let circuit = TestCircuit::<256>::new(numba);
-		let k = 9;
+		let k = 8;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
 		let res = prove_and_verify::<Bn256, _, _>(params, circuit, &[&[]], rng).unwrap();

--- a/circuit/src/gadgets/bits2num.rs
+++ b/circuit/src/gadgets/bits2num.rs
@@ -76,10 +76,8 @@ impl<F: FieldExt> Chip<F> for Bits2NumChip<F> {
 			// |          |        |    16   |    13    |
 			//
 
-			// IMPORTANT: For the maximal usage of CommonConfig columns(20 advice + 10 fixed), we use the
-			//            advice column 7 - 12. Reason is that ScalarMulChip takes advice column 0 - 6.
-			//			  It means that this chip takes the right place of ScalarMulChip in the whole circuit layout.
-			//		      Also, it means that there are advice columns 13-19 available, which other chips can use for best layout.
+			// IMPORTANT: For the maximal usage of CommonConfig columns(20 advice + 10 fixed),
+			//			  we use the advice column 7 - 12. (8th ~ 13th)
 
 			let one_exp = Expression::Constant(F::ONE);
 

--- a/circuit/src/gadgets/lt_eq.rs
+++ b/circuit/src/gadgets/lt_eq.rs
@@ -254,7 +254,7 @@ mod test {
 
 		let test_chip = TestCircuit::new(x, y);
 
-		let k = 10;
+		let k = 9;
 		let pub_ins = vec![Fr::from(0)];
 		let prover = MockProver::run(k, &test_chip, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -268,7 +268,7 @@ mod test {
 
 		let test_chip = TestCircuit::new(x, y);
 
-		let k = 10;
+		let k = 9;
 		let pub_ins = vec![Fr::from(1)];
 		let prover = MockProver::run(k, &test_chip, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -282,7 +282,7 @@ mod test {
 
 		let test_chip = TestCircuit::new(x, y);
 
-		let k = 10;
+		let k = 9;
 		let pub_ins = vec![Fr::from(0)];
 		let prover = MockProver::run(k, &test_chip, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -297,7 +297,7 @@ mod test {
 
 		let test_chip = TestCircuit::new(x, y);
 
-		let k = 10;
+		let k = 9;
 		let pub_ins = vec![Fr::from(0)];
 		let prover = MockProver::run(k, &test_chip, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -312,7 +312,7 @@ mod test {
 
 		let test_chip = TestCircuit::new(x, y);
 
-		let k = 10;
+		let k = 9;
 		let pub_ins = vec![Fr::from(1)];
 		let prover = MockProver::run(k, &test_chip, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -327,7 +327,7 @@ mod test {
 
 		let test_chip = TestCircuit::new(x, y);
 
-		let k = 10;
+		let k = 9;
 		let pub_ins = vec![Fr::from(0)];
 		let prover = MockProver::run(k, &test_chip, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
@@ -339,7 +339,7 @@ mod test {
 		let y = Fr::from(4);
 		let test_chip = TestCircuit::new(x, y);
 
-		let k = 10;
+		let k = 9;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
 		let pub_ins = [Fr::from(0)];

--- a/circuit/src/gadgets/lt_eq.rs
+++ b/circuit/src/gadgets/lt_eq.rs
@@ -35,6 +35,11 @@ impl<F: FieldExt> Chip<F> for NShiftedChip<F> {
 	type Output = AssignedCell<F, F>;
 
 	fn configure(common: &CommonConfig, meta: &mut ConstraintSystem<F>) -> Selector {
+		//
+		// IMPORTANT: For the maximal usage of CommonConfig columns(20 advice + 10 fixed),
+		//			  we use the advice column 16 - 18. (17th ~ 19th)
+		//
+
 		let selector = meta.selector();
 		let n_shifted = F::from_uniform_bytes(&to_wide(&N_SHIFTED));
 
@@ -42,9 +47,9 @@ impl<F: FieldExt> Chip<F> for NShiftedChip<F> {
 			let n_shifted_exp = Expression::Constant(n_shifted);
 
 			let s_exp = v_cells.query_selector(selector);
-			let x_exp = v_cells.query_advice(common.advice[0], Rotation::cur());
-			let y_exp = v_cells.query_advice(common.advice[1], Rotation::cur());
-			let res_exp = v_cells.query_advice(common.advice[2], Rotation::cur());
+			let x_exp = v_cells.query_advice(common.advice[16], Rotation::cur());
+			let y_exp = v_cells.query_advice(common.advice[17], Rotation::cur());
+			let res_exp = v_cells.query_advice(common.advice[18], Rotation::cur());
 
 			vec![
 				// (x + n_shifted - y) - z == 0
@@ -74,13 +79,13 @@ impl<F: FieldExt> Chip<F> for NShiftedChip<F> {
 				let mut ctx = RegionCtx::new(region, 0);
 				ctx.enable(*selector)?;
 
-				let assigned_x = ctx.copy_assign(common.advice[0], self.x.clone())?;
-				let assigned_y = ctx.copy_assign(common.advice[1], self.y.clone())?;
+				let assigned_x = ctx.copy_assign(common.advice[16], self.x.clone())?;
+				let assigned_y = ctx.copy_assign(common.advice[17], self.y.clone())?;
 
 				let n_shifted = Value::known(F::from_uniform_bytes(&to_wide(&N_SHIFTED)));
 				let res = assigned_x.value().cloned() + n_shifted - assigned_y.value();
 
-				let assigned_res = ctx.assign_advice(common.advice[2], res)?;
+				let assigned_res = ctx.assign_advice(common.advice[18], res)?;
 
 				Ok(assigned_res)
 			},

--- a/circuit/src/gadgets/range.rs
+++ b/circuit/src/gadgets/range.rs
@@ -28,12 +28,17 @@ impl<F: FieldExt, const K: usize, const S: usize> MockChip<F>
 	type Output = AssignedCell<F, F>;
 
 	fn configure(mock_common: &MockCommonConfig, meta: &mut ConstraintSystem<F>) -> Selector {
+		//
+		// IMPORTANT: For the maximal usage of CommonConfig columns(20 advice + 10 fixed),
+		//			  we use the advice column 16 - 17. (17th ~ 18th)
+		//
+
 		assert!(0 < S && S < K, "Word bits should be less than target bits.");
 
 		let bitshift_selector = meta.complex_selector();
 
-		let word_column = mock_common.common.advice[0];
-		let shifted_word_column = mock_common.common.advice[1];
+		let word_column = mock_common.common.advice[16];
+		let shifted_word_column = mock_common.common.advice[17];
 
 		meta.lookup("Check K bits limit", |meta| {
 			let bitshift_selector = meta.query_selector(bitshift_selector);
@@ -71,11 +76,11 @@ impl<F: FieldExt, const K: usize, const S: usize> MockChip<F>
 				ctx.enable(*selector)?;
 
 				// Assign original value
-				let assigned_x = ctx.copy_assign(mock_common.common.advice[0], self.x.clone())?;
+				let assigned_x = ctx.copy_assign(mock_common.common.advice[16], self.x.clone())?;
 
 				// Assign shifted value
 				let shifted_word = self.x.value().cloned() * Value::known(F::from(1 << (K - S)));
-				ctx.assign_advice(mock_common.common.advice[1], shifted_word)?;
+				ctx.assign_advice(mock_common.common.advice[17], shifted_word)?;
 
 				Ok(assigned_x)
 			},
@@ -102,9 +107,14 @@ impl<F: FieldExt, const K: usize, const N: usize> MockChip<F> for LookupRangeChe
 	type Output = (AssignedCell<F, F>, AssignedCell<F, F>);
 
 	fn configure(mock_common: &MockCommonConfig, meta: &mut ConstraintSystem<F>) -> Selector {
+		//
+		// IMPORTANT: For the maximal usage of CommonConfig columns(20 advice + 10 fixed),
+		//			  we use the advice column 16 - 17. (17th ~ 18th)
+		//
+
 		let running_sum_selector = meta.complex_selector();
 
-		let running_sum = mock_common.common.advice[0];
+		let running_sum = mock_common.common.advice[16];
 
 		meta.lookup("running_sum check", |meta| {
 			let running_sum_selector = meta.query_selector(running_sum_selector);
@@ -144,7 +154,7 @@ impl<F: FieldExt, const K: usize, const N: usize> MockChip<F> for LookupRangeChe
 			|| "range check chip",
 			|region: Region<'_, F>| {
 				let mut ctx = RegionCtx::new(region, 0);
-				let x = ctx.copy_assign(mock_common.common.advice[0], self.x.clone())?;
+				let x = ctx.copy_assign(mock_common.common.advice[16], self.x.clone())?;
 
 				// Take first "num_bits" bits of `element`.
 				let words = x
@@ -192,7 +202,7 @@ impl<F: FieldExt, const K: usize, const N: usize> MockChip<F> for LookupRangeChe
 
 					// Assign z_next
 					ctx.next();
-					z = ctx.assign_advice(mock_common.common.advice[0], z_next)?;
+					z = ctx.assign_advice(mock_common.common.advice[16], z_next)?;
 				}
 
 				ctx.constrain_to_constant(z, F::ZERO)?;

--- a/circuit/src/merkle_tree/mod.rs
+++ b/circuit/src/merkle_tree/mod.rs
@@ -311,7 +311,7 @@ mod test {
 		let leaves = vec![Fr::random(rng.clone()), Fr::random(rng.clone()), value];
 		let merkle = MerkleTree::<Fr, 2, 2, NativeH>::build_tree(leaves.clone());
 		let test_chip = MerkleTestCircuit::<2, 2>::new(leaves);
-		let k = 12;
+		let k = 8;
 		let pub_ins = vec![merkle.root];
 		let prover = MockProver::run(k, &test_chip, vec![pub_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));

--- a/circuit/src/poseidon/sponge.rs
+++ b/circuit/src/poseidon/sponge.rs
@@ -271,7 +271,7 @@ mod test {
 		let native_result = sponge.squeeze();
 		let poseidon_sponge = PoseidonTester::new(inputs);
 
-		let k = 9;
+		let k = 8;
 		let prover = MockProver::run(k, &poseidon_sponge, vec![vec![native_result]]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}
@@ -286,7 +286,7 @@ mod test {
 		let native_result = sponge.squeeze();
 		let poseidon_sponge = PoseidonTester::new(inputs);
 
-		let k = 9;
+		let k = 8;
 		let prover = MockProver::run(k, &poseidon_sponge, vec![vec![native_result]]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}

--- a/circuit/src/rescue_prime/mod.rs
+++ b/circuit/src/rescue_prime/mod.rs
@@ -355,7 +355,7 @@ mod test {
 
 		let rescue_prime_tester = RescuePrimeTester::new(inputs);
 
-		let k = 5;
+		let k = 4;
 		let prover = MockProver::run(k, &rescue_prime_tester, vec![outputs.to_vec()]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}
@@ -383,7 +383,7 @@ mod test {
 
 		let rescue_prime_tester = RescuePrimeTester::new(inputs);
 
-		let k = 5;
+		let k = 4;
 		let rng = &mut rand::thread_rng();
 		let params = generate_params(k);
 		let res =

--- a/circuit/src/rescue_prime/mod.rs
+++ b/circuit/src/rescue_prime/mod.rs
@@ -21,7 +21,7 @@ fn load_round_constants<F: FieldExt, const WIDTH: usize>(
 ) -> Result<[Value<F>; WIDTH], Error> {
 	let mut rc_values: [Value<F>; WIDTH] = [(); WIDTH].map(|_| Value::unknown());
 	for i in 0..WIDTH {
-		let rc = round_constants[(ctx.offset() / 2) * WIDTH + i];
+		let rc = round_constants[ctx.offset() * WIDTH + i];
 		ctx.assign_fixed(config.fixed[i], rc)?;
 		rc_values[i] = Value::known(rc);
 	}
@@ -59,24 +59,24 @@ where
 		let selector = meta.selector();
 
 		let state_columns: [Column<Advice>; WIDTH] = common.advice[0..WIDTH].try_into().unwrap();
+		let sbox_inv_columns: [Column<Advice>; WIDTH] =
+			common.advice[WIDTH..(2 * WIDTH)].try_into().unwrap();
 		let rc_columns: [Column<Fixed>; WIDTH] = common.fixed[0..WIDTH].try_into().unwrap();
 
 		meta.create_gate("full_round", |v_cells| {
 			//
-			//   |  i  | round |    state     |   constants   |  selector  |
-			//   |-----|-------|--------------|---------------|------------|
-			//   |  0  |   1   |  state(1)    |    const(1)   |     *      |
-			//   |  1  |       | sbox_invs(1) |               |            |
-			//   |  2  |   2   |  state(2)    |    const(2)   |     *      |
-			//   |  3  |       | sbox_invs(2) |               |            |
-			//   |  4  |   3   |  state(3)    |    const(3)   |     *      |
+			//   |  i  | round |    state     |   sbox_invs   |   constants   |  selector  |
+			//   |-----|-------|--------------|---------------|---------------|------------|
+			//   |  0  |   1   |  state(1)    |  sbox_invs(1) |    const(1)   |     *      |
+			//   |  1  |   2   |  state(2)    |  sbox_invs(2) |    const(2)   |     *      |
+			//   |  2  |   3   |  state(3)    |  sbox_invs(3) |    const(3)   |     *      |
 			//                 ...
 
 			let s_cells = v_cells.query_selector(selector);
 			let mut state = state_columns.map(|c| v_cells.query_advice(c, Rotation::cur()));
-			let sbox_inverts = state_columns.map(|c| v_cells.query_advice(c, Rotation::next()));
+			let sbox_inverts = sbox_inv_columns.map(|c| v_cells.query_advice(c, Rotation::cur()));
 			let round_constants = rc_columns.map(|c| v_cells.query_fixed(c, Rotation::cur()));
-			let next_round_constants = rc_columns.map(|c| v_cells.query_fixed(c, Rotation(2)));
+			let next_round_constants = rc_columns.map(|c| v_cells.query_fixed(c, Rotation::next()));
 
 			let mut exprs = vec![];
 
@@ -115,7 +115,7 @@ where
 
 			// It should be equal to the state in next row
 			for i in 0..WIDTH {
-				let next_state = v_cells.query_advice(state_columns[i], Rotation(2));
+				let next_state = v_cells.query_advice(state_columns[i], Rotation::next());
 				exprs.push(s_cells.clone() * (state[i].clone() - next_state));
 			}
 
@@ -161,10 +161,9 @@ where
 
 					// 4. step for the TRF
 					// Apply S-box inverse
-					ctx.next();
 					for (i, next_state_i) in next_state.iter_mut().enumerate().take(WIDTH) {
 						*next_state_i = next_state_i.map(|s| P::sbox_inv_f(s));
-						ctx.assign_advice(common.advice[i], *next_state_i)?;
+						ctx.assign_advice(common.advice[i + WIDTH], *next_state_i)?;
 					}
 
 					// 5. step for the TRF

--- a/circuit/src/rescue_prime/sponge.rs
+++ b/circuit/src/rescue_prime/sponge.rs
@@ -239,7 +239,7 @@ mod test {
 
 		let rescue_prime_sponge = RescuePrimeTester::new(inputs1, inputs2);
 
-		let k = 10;
+		let k = 5;
 		let prover = MockProver::run(k, &rescue_prime_sponge, vec![vec![native_result]]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}

--- a/circuit/src/verifier/mod.rs
+++ b/circuit/src/verifier/mod.rs
@@ -270,7 +270,7 @@ mod test {
 		}
 
 		let circuit = TestCircuitPi::<_, VERTICAL_SIZE>::new(advice, fixed);
-		let k = 8;
+		let k = 4;
 
 		let pub_ins = vec![sum; VERTICAL_SIZE];
 		let prover = MockProver::run(k, &circuit, vec![pub_ins]).unwrap();
@@ -291,7 +291,7 @@ mod test {
 		}
 		let circuit = TestCircuitPi::<_, VERTICAL_SIZE>::new(advice, fixed);
 
-		let k = 8;
+		let k = 4;
 		let params = generate_params(k);
 
 		let pub_ins = vec![sum; VERTICAL_SIZE];
@@ -313,7 +313,7 @@ mod test {
 		}
 		let circuit = TestCircuitPi::<_, VERTICAL_SIZE>::new(advice, fixed);
 
-		let k = 8;
+		let k = 4;
 		let params = read_params(k);
 		let pk = gen_pk(&params, &circuit);
 		let deployment_code = gen_evm_verifier(&params, pk.get_vk(), vec![VERTICAL_SIZE]);

--- a/circuit/src/verifier/transcript/mod.rs
+++ b/circuit/src/verifier/transcript/mod.rs
@@ -431,7 +431,7 @@ mod test {
 			);
 
 		let res = poseidon_read.squeeze_challenge();
-		let k = 9;
+		let k = 7;
 		let prover = MockProver::run(k, &TestSqueezeCircuit, vec![vec![res]]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}
@@ -708,7 +708,7 @@ mod test {
 
 		let res = poseidon_read.read_scalar().unwrap();
 		let circuit = TestReadScalarCircuit::new(reader);
-		let k = 7;
+		let k = 6;
 		let prover = MockProver::run(k, &circuit, vec![vec![res]]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}
@@ -793,7 +793,7 @@ mod test {
 		p_ins.extend(x.limbs);
 		p_ins.extend(y.limbs);
 		let circuit = TestReadEcPointCircuit::new(reader);
-		let k = 7;
+		let k = 6;
 		let prover = MockProver::run(k, &circuit, vec![p_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}
@@ -920,7 +920,7 @@ mod test {
 		p_ins.push(res);
 
 		let circuit = TestReadMultipleEcPointCircuit::new(reader);
-		let k = 7;
+		let k = 6;
 		let prover = MockProver::run(k, &circuit, vec![p_ins]).unwrap();
 		assert_eq!(prover.verify(), Ok(()));
 	}


### PR DESCRIPTION
## Description
- Update the current configurations of halo2 circuit chips so that they can maximally use all of columns in `CommonConfig`

## Related issues
Closes #292 

## Changes
- Update the config of `AbsorbChip`
- Update the config of `PointAddChip`(edwards)