### PR TITLE
feat(client): standard errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,7 @@ dependencies = [
  "secp256k1 0.27.0",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = "0.11.18"
 secp256k1 = { version = "0.27.0", features = ["global-context", "recovery"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1.0.43"
 tokio = { version = "1.18", features = ["time", "macros", "rt-multi-thread", "net"] }
 
 eigen-trust-circuit = { path = "../circuit" }

--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -223,11 +223,13 @@ impl SignedAttestation {
 
 	/// Recover the public key from the attestation signature
 	pub fn recover_public_key(&self) -> Result<ECDSAPublicKey, EigenError> {
-		let message = self.attestation.hash().to_bytes();
+		let att_hash = self.attestation.hash().to_bytes();
+		let message = Message::from_slice(att_hash.as_slice())
+			.map_err(|e| EigenError::ConversionError(e.to_string()))?;
 
 		let public_key = self
 			.signature
-			.recover(&Message::from_slice(message.as_slice()).unwrap())
+			.recover(&message)
 			.map_err(|e| EigenError::RecoveryError(e.to_string()))?;
 
 		Ok(public_key)

--- a/client/src/attestation.rs
+++ b/client/src/attestation.rs
@@ -66,7 +66,8 @@ impl Attestation {
 	/// Converts the attestation to the scalar representation.
 	pub fn to_attestation_fr(&self) -> Result<AttestationFr, &'static str> {
 		// About
-		let about = scalar_from_address(&self.about)?;
+		let about =
+			scalar_from_address(&self.about).map_err(|_| "Failed to convert address to scalar")?;
 
 		// Domain
 		let mut key_fixed: [u8; 32] = *self.key.as_fixed_bytes();
@@ -251,7 +252,7 @@ pub fn address_from_signed_att(
 	let public_key = signed_attestation.recover_public_key()?;
 
 	// Get the address from the public key
-	address_from_public_key(&public_key)
+	Ok(address_from_public_key(&public_key))
 }
 
 /// Constructs the contract attestation data from a signed attestation.

--- a/client/src/bandada.rs
+++ b/client/src/bandada.rs
@@ -18,11 +18,8 @@ impl BandadaApi {
 	/// Creates a new `BandadaApi`.
 	pub fn new(base_url: &str) -> Result<Self, EigenError> {
 		dotenv().ok();
-		let key = var("BANDADA_API_KEY").map_err(|_| {
-			EigenError::ConfigurationError(
-				"BANDADA_API_KEY environment variable is not set.".to_string(),
-			)
-		})?;
+		let key =
+			var("BANDADA_API_KEY").map_err(|e| EigenError::ConfigurationError(e.to_string()))?;
 
 		Ok(Self { base_url: base_url.to_string(), client: Client::new(), key })
 	}

--- a/client/src/bandada.rs
+++ b/client/src/bandada.rs
@@ -40,7 +40,7 @@ impl BandadaApi {
 			.headers(headers)
 			.send()
 			.await
-			.map_err(|e| EigenError::RequestError(e))
+			.map_err(EigenError::RequestError)
 	}
 
 	/// Removes Member.
@@ -58,6 +58,6 @@ impl BandadaApi {
 			.headers(headers)
 			.send()
 			.await
-			.map_err(|e| EigenError::RequestError(e))
+			.map_err(EigenError::RequestError)
 	}
 }

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -313,7 +313,7 @@ pub async fn handle_scores(
 	records_storage.save(score_records)?;
 
 	info!(
-		"Attestations saved at \"{}\".",
+		"Scores saved at \"{}\".",
 		records_storage.filepath().display()
 	);
 

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -234,7 +234,7 @@ pub async fn handle_bandada(config: &ClientConfig, data: BandadaData) -> Result<
 					"Participant not found in score records.".to_string(),
 				))?;
 
-			let participant_score: u32 = participant_record.score_fr().parse().map_err(|e| {
+			let participant_score: u32 = participant_record.score_fr().parse().map_err(|_| {
 				EigenError::ParsingError("Failed to parse participant score.".to_string())
 			})?;
 

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -281,8 +281,9 @@ pub async fn handle_scores(
 				));
 			}
 
-			let attestations: Vec<AttestationCreatedFilter> =
-				records.into_iter().map(|record| record.to_log().unwrap()).collect();
+			let results: Result<Vec<_>, _> =
+				records.into_iter().map(|record| record.to_log()).collect();
+			let attestations: Vec<AttestationCreatedFilter> = results?;
 
 			attestations
 		},
@@ -290,8 +291,9 @@ pub async fn handle_scores(
 			handle_attestations(client.get_config().clone()).await?;
 
 			let att_storage = CSVFileStorage::<AttestationRecord>::new(att_fp);
-			let attestations: Vec<AttestationCreatedFilter> =
-				att_storage.load()?.into_iter().map(|record| record.to_log().unwrap()).collect();
+			let results: Result<Vec<_>, _> =
+				att_storage.load()?.into_iter().map(|record| record.to_log()).collect();
+			let attestations: Vec<AttestationCreatedFilter> = results?;
 
 			attestations
 		},

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -43,6 +43,10 @@ pub enum EigenError {
 	#[error("RecoveryError: {0}")]
 	RecoveryError(String),
 
+	/// Request error
+	#[error("RequestError: {0}")]
+	RequestError(reqwest::Error),
+
 	/// Resource unavailable error
 	#[error("ResourceUnavailableError: {0}")]
 	ResourceUnavailableError(String),

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -23,6 +23,10 @@ pub enum EigenError {
 	#[error("ContractCompilationError: {0}")]
 	ContractCompilationError(String),
 
+	/// Conversion error
+	#[error("ConversionError: {0}")]
+	ConversionError(String),
+
 	/// File read/write error
 	#[error("FileIOError: {0}")]
 	FileIOError(String),

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -2,85 +2,60 @@
 //!
 //! This module features the `EigenError` enum for error handling throughout the project.
 
-use serde::ser::StdError;
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use thiserror::Error;
 
 /// The crate-wide error variants.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Error)]
 pub enum EigenError {
-	/// Invalid pubkey of the bootstrap peer
-	InvalidBootstrapPubkey,
-	/// Error while making proof
-	ProvingError,
-	/// Error while verifying the proof
-	VerificationError,
-	/// Client connection error
-	ConnectionError,
-	/// Failed to listen to requests
-	ListenError,
-	/// Attestation not found
-	AttestationNotFound,
-	/// Attestation verification not passed
-	InvalidAttestation,
-	/// Proof not found
-	ProofNotFound,
-	/// Parsing error
-	ParseError,
-	/// Transaction error
-	TransactionError,
+	/// Attestation error
+	#[error("AttestationError: {0}")]
+	AttestationError(String),
+
+	/// Configuration error
+	#[error("ConfigurationError: {0}")]
+	ConfigurationError(String),
+
+	/// Connection error
+	#[error("ConnectionError: {0}")]
+	ConnectionError(String),
+
 	/// Contract compilation error
-	ContractCompilationError,
-	/// Path error
-	PathError,
-	/// Unknown error.
-	Unknown,
-}
+	#[error("ContractCompilationError: {0}")]
+	ContractCompilationError(String),
 
-impl From<EigenError> for u8 {
-	fn from(e: EigenError) -> u8 {
-		match e {
-			EigenError::InvalidBootstrapPubkey => 0,
-			EigenError::ProvingError => 1,
-			EigenError::VerificationError => 2,
-			EigenError::ConnectionError => 3,
-			EigenError::ListenError => 4,
-			EigenError::AttestationNotFound => 5,
-			EigenError::ProofNotFound => 6,
-			EigenError::InvalidAttestation => 7,
-			EigenError::ParseError => 8,
-			EigenError::TransactionError => 9,
-			EigenError::ContractCompilationError => 10,
-			EigenError::PathError => 11,
-			EigenError::Unknown => 255,
-		}
-	}
-}
+	/// File read/write error
+	#[error("FileIOError: {0}")]
+	FileIOError(String),
 
-impl From<u8> for EigenError {
-	fn from(err: u8) -> Self {
-		match err {
-			0 => EigenError::InvalidBootstrapPubkey,
-			1 => EigenError::ProvingError,
-			2 => EigenError::VerificationError,
-			3 => EigenError::ConnectionError,
-			4 => EigenError::ListenError,
-			5 => EigenError::AttestationNotFound,
-			6 => EigenError::ProofNotFound,
-			7 => EigenError::InvalidAttestation,
-			8 => EigenError::ParseError,
-			9 => EigenError::TransactionError,
-			10 => EigenError::ContractCompilationError,
-			11 => EigenError::PathError,
-			_ => EigenError::Unknown,
-		}
-	}
-}
+	/// Input/output error
+	#[error("IOError: {0}")]
+	IOError(std::io::Error),
 
-impl Display for EigenError {
-	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-		write!(f, "{:?}", self)?;
-		Ok(())
-	}
-}
+	/// Network error
+	#[error("NetworkError: {0}")]
+	NetworkError(String),
 
-impl StdError for EigenError {}
+	/// Parsing error
+	#[error("ParsingError: {0}")]
+	ParsingError(String),
+
+	/// Recovery error
+	#[error("RecoveryError: {0}")]
+	RecoveryError(String),
+
+	/// Resource unavailable error
+	#[error("ResourceUnavailableError: {0}")]
+	ResourceUnavailableError(String),
+
+	/// Transaction error
+	#[error("TransactionError: {0}")]
+	TransactionError(String),
+
+	/// Unknown error
+	#[error("UnknownError: {0}")]
+	UnknownError(String),
+
+	/// Validation error
+	#[error("ValidationError: {0}")]
+	ValidationError(String),
+}

--- a/client/src/eth.rs
+++ b/client/src/eth.rs
@@ -16,6 +16,7 @@ use ethers::{
 	solc::{Artifact, CompilerOutput, Solc},
 	utils::keccak256,
 };
+use log::info;
 use secp256k1::SecretKey;
 use std::sync::Arc;
 
@@ -39,6 +40,7 @@ pub fn compile_as() -> Result<CompilerOutput, EigenError> {
 /// Generates the bindings for the AttestationStation contract and save them into a file.
 pub fn gen_as_bindings() -> Result<(), EigenError> {
 	let contracts = compile_as()?;
+	let filepath = get_file_path("attestation_station", FileType::Rs)?;
 
 	for (name, contract) in contracts.contracts_iter() {
 		let abi = contract
@@ -54,8 +56,10 @@ pub fn gen_as_bindings() -> Result<(), EigenError> {
 			.map_err(|_| EigenError::ParsingError("Error generating bindings".to_string()))?;
 
 		bindings
-			.write_to_file(get_file_path("attestation_station", FileType::Rs).unwrap())
+			.write_to_file(filepath.clone())
 			.map_err(|e| EigenError::FileIOError(e.to_string()))?;
+
+		info!("Bindings generated at {:?}", filepath);
 	}
 
 	Ok(())

--- a/client/src/eth.rs
+++ b/client/src/eth.rs
@@ -103,7 +103,8 @@ pub async fn deploy_as(signer: Arc<ClientSigner>) -> Result<Address, EigenError>
 pub fn ecdsa_secret_from_mnemonic(
 	mnemonic: &str, count: u32,
 ) -> Result<Vec<SecretKey>, EigenError> {
-	let mnemonic = Mnemonic::<English>::new_from_phrase(mnemonic).unwrap();
+	let mnemonic = Mnemonic::<English>::new_from_phrase(mnemonic)
+		.map_err(|e| EigenError::ParsingError(e.to_string()))?;
 	let mut keys = Vec::new();
 
 	// The hardened derivation flag.

--- a/client/src/eth.rs
+++ b/client/src/eth.rs
@@ -21,9 +21,7 @@ use std::sync::Arc;
 
 /// Compiles the AttestationStation contract.
 pub fn compile_as() -> Result<CompilerOutput, EigenError> {
-	let path = get_assets_path()
-		.map_err(|_| EigenError::FileIOError("Error getting assets path".to_string()))?
-		.join("AttestationStation.sol");
+	let path = get_assets_path()?.join("AttestationStation.sol");
 
 	let compiler_output = Solc::default()
 		.compile_source(path)

--- a/client/src/fs.rs
+++ b/client/src/fs.rs
@@ -53,7 +53,7 @@ pub fn get_file_path(file_name: &str, file_type: FileType) -> Result<PathBuf, Ei
 /// Reads a JSON file from the `assets` directory and returns its deserialized contents.
 pub fn read_json<T: DeserializeOwned>(file_name: &str) -> Result<T, EigenError> {
 	let json_path = get_file_path(file_name, FileType::Json)?;
-	let file = File::open(&json_path).map_err(EigenError::IOError)?;
+	let file = File::open(json_path).map_err(EigenError::IOError)?;
 	let reader = BufReader::new(file);
 	from_reader(reader).map_err(|e| EigenError::ParsingError(e.to_string()))
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -224,11 +224,11 @@ impl Client {
 
 		// Insert the attester and attested of each attestation into the set
 		for (signed_att, att) in &attestations {
-			let attester = address_from_signed_att(signed_att).unwrap();
+			let attester = address_from_signed_att(signed_att)?;
 			participants_set.insert(att.about);
 			participants_set.insert(attester);
 
-			let pk = signed_att.recover_public_key().unwrap();
+			let pk = signed_att.recover_public_key()?;
 			pks.insert(attester, pk);
 		}
 
@@ -253,7 +253,7 @@ impl Client {
 
 		// Populate the attestation matrix with the attestations data
 		for (signed_att, att) in &attestations {
-			let attester_address = address_from_signed_att(signed_att).unwrap();
+			let attester_address = address_from_signed_att(signed_att)?;
 			let attester_pos = participants.iter().position(|&r| r == attester_address).unwrap();
 			let attested_pos = participants.iter().position(|&r| r == att.about).unwrap();
 
@@ -271,7 +271,7 @@ impl Client {
 
 		// Add participants to set
 		for participant in &participants {
-			let participant_fr = scalar_from_address(participant).unwrap();
+			let participant_fr = scalar_from_address(participant)?;
 			eigen_trust_set.add_member(participant_fr);
 		}
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -191,8 +191,7 @@ impl Client {
 		let recovered_pubkey = signed_attestation
 			.recover_public_key()
 			.map_err(|e| EigenError::RecoveryError(e.to_string()))?;
-		let recovered_address = address_from_public_key(&recovered_pubkey)
-			.map_err(|e| EigenError::RecoveryError(e.to_string()))?;
+		let recovered_address = address_from_public_key(&recovered_pubkey);
 		assert!(recovered_address == self.signer.address());
 
 		// Stored contract data

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -63,7 +63,6 @@ async fn main() {
 				Ok(as_address) => info!("AttestationStation deployed at {:?}", as_address),
 				Err(e) => {
 					error!("Failed to deploy AttestationStation: {:?}", e);
-					return;
 				},
 			};
 		},

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -5,92 +5,44 @@ use clap::Parser;
 use cli::*;
 use dotenv::dotenv;
 use eigen_trust_client::{
+	error::EigenError,
 	eth::{deploy_as, gen_as_bindings},
 	fs::read_json,
 	Client, ClientConfig,
 };
 use env_logger::{init_from_env, Env};
-use log::{error, info};
+use log::info;
 
 #[tokio::main]
-async fn main() {
-	// Load .env and initialize logger
+async fn main() -> Result<(), EigenError> {
 	dotenv().ok();
 	init_from_env(Env::default().filter_or("LOG_LEVEL", "info"));
 
-	// Read configuration
-	let mut config: ClientConfig = match read_json("client_config") {
-		Ok(c) => c,
-		Err(_) => {
-			error!("Failed to read configuration file.");
-			return;
-		},
-	};
+	let mut config = read_json("client_config")?;
 
 	match Cli::parse().mode {
 		Mode::Attest(attest_data) => {
-			let attestation = match attest_data.to_attestation(&config) {
-				Ok(a) => a,
-				Err(e) => {
-					error!("Error while creating attestation: {:?}", e);
-					return;
-				},
-			};
-
+			let attestation = attest_data.to_attestation(&config)?;
 			info!("Attesting...\n{:#?}", attestation);
 
 			let client = Client::new(config);
-			if let Err(e) = client.attest(attestation).await {
-				error!("Error while attesting: {:?}", e);
-			}
+			client.attest(attestation).await?;
 		},
-		Mode::Attestations => match handle_attestations(config).await {
-			Ok(_) => (),
-			Err(e) => error!("Failed to execute attestations command: {:?}", e),
-		},
-		Mode::Bandada(bandada_data) => match handle_bandada(&config, bandada_data).await {
-			Ok(_) => (),
-			Err(e) => error!("Failed to execute bandada command: {:?}", e),
-		},
-		Mode::Compile => match gen_as_bindings() {
-			Ok(_) => info!("Compilation successful"),
-			Err(e) => error!("Error during compilation: {}", e),
-		},
+		Mode::Attestations => handle_attestations(config).await?,
+		Mode::Bandada(bandada_data) => handle_bandada(&config, bandada_data).await?,
+		Mode::Compile => gen_as_bindings()?,
 		Mode::Deploy => {
 			let client = Client::new(config);
-
-			match deploy_as(client.get_signer()).await {
-				Ok(as_address) => info!("AttestationStation deployed at {:?}", as_address),
-				Err(e) => {
-					error!("Failed to deploy AttestationStation: {:?}", e);
-				},
-			};
+			let as_address = deploy_as(client.get_signer()).await?;
+			info!("AttestationStation deployed at {:?}", as_address);
 		},
-		Mode::LocalScores => match handle_scores(config, AttestationsOrigin::Local).await {
-			Ok(_) => info!("Scores calculated."),
-			Err(e) => error!("LocalScores command failed: {}", e),
-		},
-		Mode::Proof => {
-			info!("Not implemented yet.");
-		},
-		Mode::Scores => match handle_scores(config, AttestationsOrigin::Fetch).await {
-			Ok(_) => info!("Scores calculated."),
-			Err(e) => error!("Scores command failed: {}", e),
-		},
+		Mode::LocalScores => handle_scores(config, AttestationsOrigin::Local).await?,
+		Mode::Proof => info!("Not implemented yet."),
+		Mode::Scores => handle_scores(config, AttestationsOrigin::Fetch).await?,
 		Mode::Show => info!("Client config:\n{:#?}", config),
-		Mode::Update(update_data) => match handle_update(&mut config, update_data) {
-			Ok(_) => info!("Client configuration updated."),
-			Err(e) => error!("Failed to update client configuration: {}", e),
-		},
-		Mode::Verify => {
-			let client = Client::new(config);
+		Mode::Update(update_data) => handle_update(&mut config, update_data)?,
+		Mode::Verify => info!("Not implemented yet."),
+	};
 
-			if let Err(e) = client.verify().await {
-				error!("Failed to verify the proof: {:?}", e);
-				return;
-			}
-
-			info!("Proof verified.");
-		},
-	}
+	Ok(())
 }

--- a/client/src/storage.rs
+++ b/client/src/storage.rs
@@ -195,12 +195,12 @@ pub struct AttestationRecord {
 
 impl AttestationRecord {
 	/// Creates a new AttestationRecord from an Attestation log.
-	pub fn from_log(log: &AttestationCreatedFilter) -> Self {
-		let payload = AttestationPayload::from_log(log).unwrap();
-		let attestation = Attestation::from_log(log).unwrap();
+	pub fn from_log(log: &AttestationCreatedFilter) -> Result<Self, EigenError> {
+		let payload = AttestationPayload::from_log(log)?;
+		let attestation = Attestation::from_log(log)?;
 		let (sig_r, sig_s, rec_id) = payload.get_raw_signature();
 
-		Self {
+		Ok(Self {
 			about: Self::encode_bytes_to_hex(attestation.about.as_fixed_bytes()),
 			key: Self::encode_bytes_to_hex(attestation.key.as_fixed_bytes()),
 			value: attestation.value.to_string(),
@@ -208,11 +208,11 @@ impl AttestationRecord {
 			sig_r: Self::encode_bytes_to_hex(&sig_r),
 			sig_s: Self::encode_bytes_to_hex(&sig_s),
 			rec_id: rec_id.to_string(),
-		}
+		})
 	}
 
 	/// Returns a log from an AttestationRecord.
-	pub fn to_log(&self) -> Result<AttestationCreatedFilter, &'static str> {
+	pub fn to_log(&self) -> Result<AttestationCreatedFilter, EigenError> {
 		// Use helper functions to simplify the conversion process
 		let about = Address::from_slice(&Self::decode_hex_to_bytes(&self.about)?);
 		let key = Self::parse_bytes32(&self.key)?;
@@ -229,18 +229,18 @@ impl AttestationRecord {
 		// Recover the signature
 		let attestation =
 			Attestation::new(about, H256::from(key), value, Some(H256::from(message)));
-		let att_fr = attestation.to_attestation_fr().unwrap();
+		let att_fr = attestation.to_attestation_fr()?;
 		let recoverable_sig = payload.get_signature();
 
 		let signed_att = SignedAttestation::new(att_fr, recoverable_sig);
-		let creator = address_from_signed_att(&signed_att).unwrap();
+		let creator = address_from_signed_att(&signed_att)?;
 
 		Ok(AttestationCreatedFilter { about, key, val, creator })
 	}
 
 	// Helper function for decoding hexadecimal string into a byte array
-	fn decode_hex_to_bytes(hex_str: &str) -> Result<Vec<u8>, &'static str> {
-		hex::decode(&hex_str[2..]).map_err(|_| "Failed to decode hexadecimal string")
+	fn decode_hex_to_bytes(hex_str: &str) -> Result<Vec<u8>, EigenError> {
+		hex::decode(&hex_str[2..]).map_err(|e| EigenError::ParsingError(e.to_string()))
 	}
 
 	// Helper function for encoding byte array into hexadecimal string
@@ -249,16 +249,17 @@ impl AttestationRecord {
 	}
 
 	// Helper function for parsing string into a byte array
-	fn parse_bytes32(hex_str: &str) -> Result<[u8; 32], &'static str> {
+	fn parse_bytes32(hex_str: &str) -> Result<[u8; 32], EigenError> {
 		let bytes = Self::decode_hex_to_bytes(hex_str)?;
-		let bytes_array: [u8; 32] =
-			bytes.try_into().map_err(|_| "Failed to convert into byte array")?;
+		let bytes_array: [u8; 32] = bytes.try_into().map_err(|_| {
+			EigenError::ConversionError("Failed to convert into byte array".to_string())
+		})?;
 		Ok(bytes_array)
 	}
 
 	// Helper function for parsing string into u8
-	fn parse_u8(value: &str) -> Result<u8, &'static str> {
-		value.parse::<u8>().map_err(|_| "Failed to parse into u8")
+	fn parse_u8(value: &str) -> Result<u8, EigenError> {
+		value.parse::<u8>().map_err(|e| EigenError::ParsingError(e.to_string()))
 	}
 }
 

--- a/client/src/storage.rs
+++ b/client/src/storage.rs
@@ -78,7 +78,7 @@ impl<T: Serialize + DeserializeOwned + Clone> Storage<Vec<T>> for CSVFileStorage
 	type Err = EigenError;
 
 	fn load(&self) -> Result<Vec<T>, EigenError> {
-		let file = File::open(&self.filepath).map_err(|e| EigenError::IOError(e))?;
+		let file = File::open(&self.filepath).map_err(EigenError::IOError)?;
 		let mut reader = ReaderBuilder::new().from_reader(BufReader::new(file));
 
 		reader


### PR DESCRIPTION
# Description

This PR aims to implement the usage of the `EigenError` variants across the whole client.

## Related Issues

- Resolves #297 

# Changes

- Add `thiserror` dependency.
- Update error types.