### PR TITLE
feat(lib): standard client interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,6 @@ dependencies = [
  "eigentrust-zk",
  "ethers",
  "log",
- "rand",
  "secp256k1 0.27.0",
  "serde",
  "serde_json",

--- a/eigentrust-cli/src/cli.rs
+++ b/eigentrust-cli/src/cli.rs
@@ -9,17 +9,15 @@ use crate::{
 };
 use clap::{Args, Parser, Subcommand};
 use eigentrust::{
-	att_station::AttestationCreatedFilter,
-	attestation::AttestationEth,
+	attestation::{AttestationRaw, SignedAttestationRaw},
 	error::EigenError,
-	storage::{AttestationRecord, CSVFileStorage, JSONFileStorage, ScoreRecord, Storage},
+	storage::{
+		str_to_20_byte_array, str_to_32_byte_array, AttestationRecord, CSVFileStorage,
+		JSONFileStorage, ScoreRecord, Storage,
+	},
 	Client,
 };
-use ethers::{
-	abi::Address,
-	providers::Http,
-	types::{Uint8, H160, H256},
-};
+use ethers::{abi::Address, providers::Http, types::H160};
 use log::info;
 use std::str::FromStr;
 
@@ -124,40 +122,31 @@ pub enum AttestationsOrigin {
 }
 
 impl AttestData {
-	/// Converts `AttestData` to `Attestation`.
-	pub fn to_attestation(&self, config: &ClientConfig) -> Result<AttestationEth, EigenError> {
+	pub fn to_attestation_raw(&self, config: &ClientConfig) -> Result<AttestationRaw, EigenError> {
 		// Parse Address
-		let parsed_address: Address = self
+		let about = self
 			.address
 			.as_ref()
-			.ok_or_else(|| EigenError::ParsingError("Missing address".to_string()))?
-			.parse()
-			.map_err(|_| EigenError::ParsingError("Failed to parse address.".to_string()))?;
+			.ok_or_else(|| EigenError::ValidationError("Missing address".to_string()))
+			.and_then(|address| str_to_20_byte_array(address))?;
 
-		// Domain
-		let domain = H160::from_str(&config.domain)
-			.map_err(|_| EigenError::ParsingError("Failed to parse domain".to_string()))?;
+		// Use the `ClientConfig` instance to get domain
+		let domain = str_to_20_byte_array(&config.domain)?;
 
 		// Parse score
-		let parsed_score: u8 = self
+		let value = self
 			.score
 			.as_ref()
-			.ok_or_else(|| EigenError::ParsingError("Missing score".to_string()))?
-			.parse::<u8>()
-			.map_err(|e| EigenError::ParsingError(e.to_string()))?;
-		let score = Uint8::from(parsed_score);
+			.ok_or_else(|| EigenError::ValidationError("Missing score".to_string()))
+			.and_then(|score| {
+				score.parse::<u8>().map_err(|e| EigenError::ParsingError(e.to_string()))
+			})?;
 
 		// Parse message
-		let message = match &self.message {
-			Some(message_str) => {
-				let message = H256::from_str(message_str)
-					.map_err(|e| EigenError::ParsingError(e.to_string()))?;
-				Some(message)
-			},
-			None => None,
-		};
+		let message =
+			self.message.as_ref().map_or(Ok([0u8; 32]), |message| str_to_32_byte_array(message))?;
 
-		Ok(AttestationEth::new(parsed_address, domain, score, message))
+		Ok(AttestationRaw::new(about, domain, value, message))
 	}
 }
 
@@ -186,10 +175,8 @@ pub async fn handle_attestations(config: ClientConfig) -> Result<(), EigenError>
 		));
 	}
 
-	let attestation_records = attestations
-		.into_iter()
-		.map(|log| AttestationRecord::from_log(&log))
-		.collect::<Result<Vec<AttestationRecord>, EigenError>>()?;
+	let attestation_records: Vec<AttestationRecord> =
+		attestations.into_iter().map(|attestation| attestation.into()).collect();
 
 	let filepath = get_file_path("attestations", FileType::Csv)?;
 
@@ -272,7 +259,7 @@ pub async fn handle_scores(
 	let att_fp = get_file_path("attestations", FileType::Csv)?;
 
 	// Get or Fetch attestations
-	let attestations = match origin {
+	let attestations: Vec<SignedAttestationRaw> = match origin {
 		AttestationsOrigin::Local => {
 			let att_storage = CSVFileStorage::<AttestationRecord>::new(att_fp);
 
@@ -285,21 +272,19 @@ pub async fn handle_scores(
 				));
 			}
 
-			let results: Result<Vec<_>, _> =
-				records.into_iter().map(|record| record.to_log()).collect();
-			let attestations: Vec<AttestationCreatedFilter> = results?;
+			let attestations: Result<Vec<SignedAttestationRaw>, EigenError> =
+				records.into_iter().map(|record| record.try_into()).collect();
 
-			attestations
+			attestations?
 		},
 		AttestationsOrigin::Fetch => {
 			handle_attestations(client.get_config().clone()).await?;
 
 			let att_storage = CSVFileStorage::<AttestationRecord>::new(att_fp);
-			let results: Result<Vec<_>, _> =
-				att_storage.load()?.into_iter().map(|record| record.to_log()).collect();
-			let attestations: Vec<AttestationCreatedFilter> = results?;
+			let attestations: Result<Vec<SignedAttestationRaw>, EigenError> =
+				att_storage.load()?.into_iter().map(|record| record.try_into()).collect();
 
-			attestations
+			attestations?
 		},
 	};
 
@@ -375,9 +360,11 @@ pub fn handle_update(config: &mut ClientConfig, data: UpdateData) -> Result<(), 
 mod tests {
 	use crate::cli::{AttestData, Cli};
 	use clap::CommandFactory;
-	use eigentrust::{attestation::AttestationEth, ClientConfig};
-	use ethers::types::{Uint8, H160, H256};
-	use std::str::FromStr;
+	use eigentrust::{
+		attestation::AttestationRaw,
+		storage::{str_to_20_byte_array, str_to_32_byte_array},
+		ClientConfig,
+	};
 
 	#[test]
 	fn test_cli() {
@@ -385,7 +372,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_attest_data_to_attestation() {
+	fn test_attest_data_to_attestation_raw() {
 		let config = ClientConfig {
 			as_address: "test".to_string(),
 			band_id: "38922764296632428858395574229367".to_string(),
@@ -396,29 +383,28 @@ mod tests {
 			node_url: "http://localhost:8545".to_string(),
 		};
 
+		let address = "0x5fbdb2315678afecb367f032d93f642f64180aa3".to_string();
+		let score = "5".to_string();
+		let message =
+			"473fe1d0de78c8f334d059013d902c13c8b53eb0f669caa9cad677ce1a601167".to_string();
+
 		let data = AttestData {
-			address: Some("0x5fbdb2315678afecb367f032d93f642f64180aa3".to_string()),
-			score: Some("5".to_string()),
-			message: Some(
-				"473fe1d0de78c8f334d059013d902c13c8b53eb0f669caa9cad677ce1a601167".to_string(),
-			),
+			address: Some(address.clone()),
+			score: Some(score),
+			message: Some(message.clone()),
 		};
 
-		let attestation = data.to_attestation(&config).unwrap();
+		let attestation = data.to_attestation_raw(&config).unwrap();
 
-		let expected_about = "0x5fbdb2315678afecb367f032d93f642f64180aa3".parse().unwrap();
-		let expected_domain = H160::from([0; 20]);
-		let expected_value = Uint8::from(5);
-		let expected_message = H256::from_str(
-			&"473fe1d0de78c8f334d059013d902c13c8b53eb0f669caa9cad677ce1a601167".to_string(),
-		)
-		.unwrap();
-		let expected_attestation = AttestationEth::new(
-			expected_about,
-			expected_domain,
-			expected_value,
-			Some(expected_message),
+		let expected_about = str_to_20_byte_array(&address).unwrap();
+		let expected_domain = str_to_20_byte_array(&config.domain).unwrap();
+		let expected_value = 5u8;
+		let expected_message = str_to_32_byte_array(&message).unwrap();
+
+		let expected_attestation = AttestationRaw::new(
+			expected_about, expected_domain, expected_value, expected_message,
 		);
+
 		assert_eq!(attestation, expected_attestation);
 	}
 }

--- a/eigentrust-cli/src/main.rs
+++ b/eigentrust-cli/src/main.rs
@@ -38,7 +38,7 @@ use eigentrust::{
 };
 use env_logger::{init_from_env, Env};
 use fs::{load_config, load_mnemonic};
-use log::info;
+use log::{debug, info};
 
 #[tokio::main]
 async fn main() -> Result<(), EigenError> {
@@ -48,8 +48,8 @@ async fn main() -> Result<(), EigenError> {
 
 	match Cli::parse().mode {
 		Mode::Attest(attest_data) => {
-			let attestation = attest_data.to_attestation(&config)?;
-			info!("Attesting...\n{:#?}", attestation);
+			let attestation = attest_data.to_attestation_raw(&config)?;
+			debug!("Attesting:{:?}", attestation);
 
 			let mnemonic = load_mnemonic();
 			let client = Client::new(config, mnemonic);

--- a/eigentrust/Cargo.toml
+++ b/eigentrust/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 csv = "1.1"
 ethers = { version = "=1.0.2", features = ["ethers-solc", "ws"] }
 log = "0.4.19"
-rand = "0.8"
 secp256k1 = { version = "0.27.0", features = ["global-context", "recovery"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/eigentrust/src/attestation.rs
+++ b/eigentrust/src/attestation.rs
@@ -277,7 +277,7 @@ impl From<SignedAttestationRaw> for SignedAttestationEth {
 }
 
 /// Attestation struct.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AttestationRaw {
 	/// Ethereum address of peer being rated
 	pub(crate) about: [u8; 20],
@@ -337,6 +337,33 @@ impl From<AttestationEth> for AttestationRaw {
 		let value = u8::from(att_eth.value);
 
 		Self { about, domain, value, message }
+	}
+}
+
+impl TryFrom<AttestationCreatedFilter> for AttestationRaw {
+	type Error = EigenError;
+
+	fn try_from(log: AttestationCreatedFilter) -> Result<Self, Self::Error> {
+		let about = log.about.to_fixed_bytes();
+
+		let mut domain: [u8; 20] = [0; 20];
+		domain.copy_from_slice(&log.key[DOMAIN_PREFIX_LEN..32]);
+
+		let (value, message): (u8, [u8; 32]) = match log.val.len() {
+			66 => (log.val[65], [0; 32]),
+			98 => {
+				let mut message = [0; 32];
+				message.copy_from_slice(&log.val[66..]);
+				(log.val[65], message)
+			},
+			_ => {
+				return Err(EigenError::ValidationError(
+					"Invalid attestation".to_string(),
+				))
+			},
+		};
+
+		Ok(AttestationRaw { about, domain, value, message })
 	}
 }
 
@@ -426,6 +453,30 @@ impl From<SignatureEth> for SignatureRaw {
 		let rec_id = u8::from(att_eth.rec_id);
 
 		Self { sig_r, sig_s, rec_id }
+	}
+}
+
+impl TryFrom<AttestationCreatedFilter> for SignatureRaw {
+	type Error = EigenError;
+
+	fn try_from(log: AttestationCreatedFilter) -> Result<Self, Self::Error> {
+		let len = log.val.len();
+		if len != 66 && len != 98 {
+			return Err(EigenError::ValidationError(
+				"Invalid length: expected 66 or 98, got".to_string(),
+			));
+		}
+
+		let sig_r: [u8; 32] = log.val[..32].try_into().map_err(|_| {
+			EigenError::ValidationError("'sig_r' conversion to 32-byte array failed".to_string())
+		})?;
+		let sig_s: [u8; 32] = log.val[32..64].try_into().map_err(|_| {
+			EigenError::ValidationError("'sig_s' conversion to 32-byte array failed".to_string())
+		})?;
+
+		let rec_id = log.val[64];
+
+		Ok(SignatureRaw { sig_r, sig_s, rec_id })
 	}
 }
 

--- a/eigentrust/src/lib.rs
+++ b/eigentrust/src/lib.rs
@@ -58,14 +58,13 @@ use crate::attestation::{SignatureEth, SignatureRaw, SignedAttestationEth};
 use att_station::{
 	AttestationCreatedFilter, AttestationData as ContractAttestationData, AttestationStation,
 };
-use attestation::AttestationEth;
+use attestation::{AttestationEth, AttestationRaw, SignedAttestationRaw};
 use eigentrust_zk::{
 	circuits::dynamic_sets::ecdsa_native::{
-		EigenTrustSet, RationalScore, SignedAttestation as SignedAttestationFr, MIN_PEER_COUNT,
-		NUM_BITS, NUM_LIMBS,
+		EigenTrustSet, SignedAttestation as SignedAttestationFr, MIN_PEER_COUNT, NUM_BITS,
+		NUM_LIMBS,
 	},
 	ecdsa::native::PublicKey,
-	halo2::halo2curves::bn256::Fr as Scalar,
 };
 use error::EigenError;
 use eth::{address_from_public_key, ecdsa_secret_from_mnemonic, scalar_from_address};
@@ -100,6 +99,8 @@ const INITIAL_SCORE: u128 = 1000;
 const _NUM_DECIMAL_LIMBS: usize = 2;
 /// Number of digits of each limbs for threshold checking.
 const _POWER_OF_TEN: usize = 72;
+/// Signer type alias.
+pub type ClientSigner = SignerMiddleware<Provider<Http>, LocalWallet>;
 
 /// Client configuration settings.
 #[derive(Serialize, Deserialize, Debug, EthDisplay, Clone)]
@@ -120,10 +121,17 @@ pub struct ClientConfig {
 	pub node_url: String,
 }
 
-/// Signer type alias.
-pub type ClientSigner = SignerMiddleware<Provider<Http>, LocalWallet>;
-/// Scores type alias.
-pub type Score = (Address, Scalar, RationalScore);
+/// Score struct.
+pub struct Score {
+	/// Participant address.
+	pub address: [u8; 20],
+	/// Scalar score.
+	pub score_fr: [u8; 32],
+	/// Rational score (numerator, denominator).
+	pub score_rat: ([u8; 32], [u8; 32]),
+	/// Hexadecimal score.
+	pub score_hex: [u8; 32],
+}
 
 /// Client struct.
 pub struct Client {
@@ -156,11 +164,11 @@ impl Client {
 	}
 
 	/// Submits an attestation to the attestation station.
-	pub async fn attest(&self, attestation_eth: AttestationEth) -> Result<(), EigenError> {
+	pub async fn attest(&self, attestation: AttestationRaw) -> Result<(), EigenError> {
 		let ctx = SECP256K1;
 		let secret_keys = ecdsa_secret_from_mnemonic(&self.mnemonic, 1)?;
 
-		// Get AttestationFr
+		let attestation_eth = AttestationEth::from(attestation);
 		let attestation_fr = attestation_eth.to_attestation_fr()?;
 
 		// Format for signature
@@ -208,13 +216,11 @@ impl Client {
 
 	/// Calculates the EigenTrust global scores.
 	pub async fn calculate_scores(
-		&self, att: Vec<AttestationCreatedFilter>,
+		&self, att: Vec<SignedAttestationRaw>,
 	) -> Result<Vec<Score>, EigenError> {
 		// Parse attestation logs into signed attestation and attestation structs
-		let attestations: Vec<SignedAttestationEth> = att
-			.into_iter()
-			.map(|attestation_filter| SignedAttestationEth::from_log(&attestation_filter))
-			.collect::<Result<Vec<_>, EigenError>>()?;
+		let attestations: Vec<SignedAttestationEth> =
+			att.into_iter().map(|signed_raw| signed_raw.into()).collect();
 
 		// Construct a set to hold unique participant addresses
 		let mut participants_set = BTreeSet::<Address>::new();
@@ -309,7 +315,21 @@ impl Client {
 			.zip(scores_fr.iter())
 			.zip(scores_rat.iter())
 			.map(|((&participant, &score_fr), score_rat)| {
-				(participant, score_fr, score_rat.clone())
+				let address = participant.to_fixed_bytes();
+
+				let mut scalar = score_fr.to_bytes();
+				scalar.reverse();
+
+				let mut numerator: [u8; 32] = [0; 32];
+				numerator.copy_from_slice(score_rat.numer().to_bytes_be().1.as_slice());
+
+				let mut denominator: [u8; 32] = [0; 32];
+				denominator.copy_from_slice(score_rat.denom().to_bytes_be().1.as_slice());
+
+				let mut score_hex: [u8; 32] = [0; 32];
+				score_hex.copy_from_slice(score_rat.to_integer().to_bytes_be().1.as_slice());
+
+				Score { address, score_fr: scalar, score_rat: (numerator, denominator), score_hex }
 			})
 			.collect();
 
@@ -317,19 +337,29 @@ impl Client {
 	}
 
 	/// Fetches attestations from the contract.
-	pub async fn get_attestations(&self) -> Result<Vec<AttestationCreatedFilter>, EigenError> {
-		// Get the logs from the contract
-		let logs = self.get_logs().await?;
+	pub async fn get_attestations(&self) -> Result<Vec<SignedAttestationRaw>, EigenError> {
+		let att_logs: Result<Vec<AttestationCreatedFilter>, EigenError> = self
+			.get_logs()
+			.await?
+			.iter()
+			.map(|log| {
+				let raw_log = RawLog::from((log.topics.clone(), log.data.to_vec()));
+				AttestationCreatedFilter::decode_log(&raw_log)
+					.map_err(|e| EigenError::ParsingError(e.to_string()))
+			})
+			.collect();
 
-		// Decode the logs into attestations
-		let mut attestations: Vec<AttestationCreatedFilter> = Vec::new();
-		for log in logs.iter() {
-			let raw_log = RawLog::from((log.topics.clone(), log.data.to_vec()));
-			let att = AttestationCreatedFilter::decode_log(&raw_log).unwrap();
-			attestations.push(att);
-		}
+		// Convert logs into signed attestations
+		let signed_attestations: Result<Vec<SignedAttestationRaw>, _> = att_logs?
+			.into_iter()
+			.map(|log| {
+				let att_raw: AttestationRaw = log.clone().try_into()?;
+				let sig_raw: SignatureRaw = log.try_into()?;
+				Ok(SignedAttestationRaw::new(att_raw, sig_raw))
+			})
+			.collect();
 
-		Ok(attestations)
+		signed_attestations
 	}
 
 	/// Fetches logs from the contract.
@@ -363,12 +393,8 @@ impl Client {
 
 #[cfg(test)]
 mod lib_tests {
-	use crate::{attestation::AttestationEth, eth::deploy_as, Client, ClientConfig};
-	use ethers::{
-		abi::Address,
-		types::{Uint8, H160, H256},
-		utils::Anvil,
-	};
+	use crate::{attestation::AttestationRaw, eth::deploy_as, Client, ClientConfig};
+	use ethers::utils::Anvil;
 
 	const TEST_MNEMONIC: &'static str =
 		"test test test test test test test test test test test junk";
@@ -404,8 +430,7 @@ mod lib_tests {
 		let updated_client = Client::new(updated_config, TEST_MNEMONIC.to_string());
 
 		// Attest
-		let attestation =
-			AttestationEth::new(Address::default(), H160::default(), Uint8::default(), None);
+		let attestation = AttestationRaw::new([0; 20], [0; 20], 5, [0; 32]);
 		assert!(updated_client.attest(attestation).await.is_ok());
 
 		drop(anvil);
@@ -451,18 +476,15 @@ mod lib_tests {
 			0x36, 0x53, 0x62, 0x6d, 0x35, 0xff,
 		];
 
+		let value: u8 = 10;
+
 		let message = [
 			0x00, 0x75, 0x32, 0x45, 0x75, 0x79, 0x32, 0x77, 0x7a, 0x34, 0x58, 0x6c, 0x34, 0x34,
 			0x4a, 0x74, 0x6a, 0x78, 0x68, 0x4c, 0x4a, 0x52, 0x67, 0x48, 0x45, 0x6c, 0x4e, 0x73,
 			0x65, 0x6e, 0x79, 0x00,
 		];
 
-		let attestation = AttestationEth::new(
-			Address::from(about_bytes),
-			H160::from(domain_input),
-			Uint8::from(10),
-			Some(H256::from(message)),
-		);
+		let attestation = AttestationRaw::new(about_bytes, domain_input, value, message);
 
 		client.attest(attestation.clone()).await.unwrap();
 
@@ -470,15 +492,13 @@ mod lib_tests {
 
 		assert_eq!(attestations.len(), 1);
 
-		let att_logs = attestations[0].clone();
-
-		let returned_att = AttestationEth::from_log(&att_logs).unwrap();
+		let fetched_att = attestations[0].clone().attestation;
 
 		// Check that the attestations match
-		assert_eq!(returned_att.about, attestation.about);
-		assert_eq!(returned_att.domain, attestation.about);
-		assert_eq!(returned_att.value, attestation.value);
-		assert_eq!(returned_att.message, attestation.message);
+		assert_eq!(fetched_att.about, about_bytes);
+		assert_eq!(fetched_att.domain, domain_input);
+		assert_eq!(fetched_att.value, value);
+		assert_eq!(fetched_att.message, message);
 
 		drop(anvil);
 	}

--- a/eigentrust/src/storage.rs
+++ b/eigentrust/src/storage.rs
@@ -3,21 +3,22 @@
 //! This module contains generic storage traits and implementations.
 
 use crate::{
-	att_station::AttestationCreatedFilter,
-	attestation::{AttestationRaw, SignatureRaw, SignedAttestationEth, SignedAttestationRaw},
+	attestation::{AttestationRaw, SignatureRaw, SignedAttestationRaw},
 	error::EigenError,
-	eth::address_from_public_key,
 	Score,
 };
 use csv::{ReaderBuilder, WriterBuilder};
-use ethers::utils::hex;
+use ethers::{
+	types::{H160, H256},
+	utils::hex,
+};
 use serde::Deserialize;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{from_reader, to_string};
-use std::fs::File;
 use std::io::{BufReader, Write};
 use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::{fs::File, str::FromStr};
 
 /// The main trait to be implemented by different storage types.
 pub trait Storage<T> {
@@ -131,22 +132,15 @@ impl ScoreRecord {
 
 	/// Creates a new score record from a score.
 	pub fn from_score(score: Score) -> Self {
-		let (participant, score_fr, score_rat) = score;
+		let peer_address = Self::to_hex_string(&score.address, true);
+		let score_fr_hex = Self::to_hex_string(&score.score_fr, true);
+		let numerator = Self::to_hex_string(&score.score_rat.0, false);
+		let denominator = Self::to_hex_string(&score.score_rat.1, false);
+		let score_hex = Self::to_hex_string(&score.score_hex, true);
 
-		let peer_address = format!("{:?}", participant);
-
-		let score_fr_hex = {
-			let mut score_fr_bytes = score_fr.to_bytes();
-			score_fr_bytes.reverse(); // Reverse bytes for big endian format
-			score_fr_bytes.iter().map(|byte| format!("{:02x}", byte)).collect::<String>()
-		};
-		let score_fr_hex = format!("0x{}", score_fr_hex);
-
-		let numerator = score_rat.numer().to_string();
-		let denominator = score_rat.denom().to_string();
-		let score = score_rat.to_integer().to_string();
-
-		Self::new(peer_address, score_fr_hex, numerator, denominator, score)
+		Self::new(
+			peer_address, score_fr_hex, numerator, denominator, score_hex,
+		)
 	}
 
 	/// Returns the peer's address.
@@ -173,6 +167,16 @@ impl ScoreRecord {
 	pub fn score(&self) -> &String {
 		&self.score
 	}
+
+	/// Converts bytes to a hexadecimal string.
+	fn to_hex_string(bytes: &[u8], prefix: bool) -> String {
+		let hex_string = bytes.iter().map(|byte| format!("{:02x}", byte)).collect::<String>();
+		if prefix {
+			format!("0x{}", hex_string)
+		} else {
+			hex_string
+		}
+	}
 }
 
 /// Attestation record.
@@ -194,82 +198,63 @@ pub struct AttestationRecord {
 	rec_id: String,
 }
 
-impl AttestationRecord {
-	/// Creates a new AttestationRecord from an Attestation log.
-	pub fn from_log(log: &AttestationCreatedFilter) -> Result<Self, EigenError> {
-		let sign_att_eth = SignedAttestationEth::from_log(log)?;
-		let sign_att_raw: SignedAttestationRaw = sign_att_eth.into();
+impl From<SignedAttestationRaw> for AttestationRecord {
+	fn from(raw: SignedAttestationRaw) -> Self {
+		let SignedAttestationRaw { attestation, signature } = raw;
+		let AttestationRaw { about, domain, value, message } = attestation;
+		let SignatureRaw { sig_r, sig_s, rec_id } = signature;
 
-		Ok(Self {
-			about: Self::encode_bytes_to_hex(&sign_att_raw.attestation.about),
-			domain: Self::encode_bytes_to_hex(&sign_att_raw.attestation.domain),
-			value: sign_att_raw.attestation.value.to_string(),
-			message: Self::encode_bytes_to_hex(&sign_att_raw.attestation.message),
-			sig_r: Self::encode_bytes_to_hex(&sign_att_raw.signature.sig_r),
-			sig_s: Self::encode_bytes_to_hex(&sign_att_raw.signature.sig_s),
-			rec_id: sign_att_raw.signature.rec_id.to_string(),
-		})
+		Self {
+			about: format!("0x{}", hex::encode(about)),
+			domain: format!("0x{}", hex::encode(domain)),
+			value: value.to_string(),
+			message: format!("0x{}", hex::encode(message)),
+			sig_r: format!("0x{}", hex::encode(sig_r)),
+			sig_s: format!("0x{}", hex::encode(sig_s)),
+			rec_id: rec_id.to_string(),
+		}
 	}
+}
 
-	/// Returns a log from an AttestationRecord.
-	pub fn to_log(&self) -> Result<AttestationCreatedFilter, EigenError> {
-		// Use helper functions to simplify the conversion process
-		let sig_r = Self::parse_bytes32(&self.sig_r)?;
-		let sig_s = Self::parse_bytes32(&self.sig_s)?;
-		let rec_id = Self::parse_u8(&self.rec_id)?;
+impl TryFrom<AttestationRecord> for SignedAttestationRaw {
+	type Error = EigenError;
 
-		let about = Self::parse_bytes20(&self.about)?;
-		let domain = Self::parse_bytes20(&self.domain)?;
-		let value = Self::parse_u8(&self.value)?;
-		let message = Self::parse_bytes32(&self.message)?;
+	fn try_from(record: AttestationRecord) -> Result<Self, Self::Error> {
+		let AttestationRecord { about, domain, value, message, sig_r, sig_s, rec_id } = record;
 
-		// Construct AttestationPayload and serialize it
-		let att_raw = AttestationRaw::new(about, domain, value, message);
-		let sig_raw = SignatureRaw::new(sig_r, sig_s, rec_id);
-		let sign_att_raw = SignedAttestationRaw::new(att_raw, sig_raw);
-		let sign_att_eth: SignedAttestationEth = sign_att_raw.into();
+		let attestation = AttestationRaw {
+			about: str_to_20_byte_array(&about)?,
+			domain: str_to_20_byte_array(&domain)?,
+			value: value
+				.parse::<u8>()
+				.map_err(|_| EigenError::ConversionError("Failed to parse 'value'".to_string()))?,
+			message: str_to_32_byte_array(&message)?,
+		};
 
-		let about = sign_att_eth.attestation.about;
-		let key = *sign_att_eth.attestation.get_key().as_fixed_bytes();
-		let val = sign_att_eth.to_payload();
-		let public_key = sign_att_eth.recover_public_key()?;
-		let creator = address_from_public_key(&public_key);
+		let signature = SignatureRaw {
+			sig_r: str_to_32_byte_array(&sig_r)?,
+			sig_s: str_to_32_byte_array(&sig_s)?,
+			rec_id: rec_id
+				.parse::<u8>()
+				.map_err(|_| EigenError::ConversionError("Failed to parse 'rec_id'".to_string()))?,
+		};
 
-		Ok(AttestationCreatedFilter { about, key, val, creator })
+		Ok(Self { attestation, signature })
 	}
+}
 
-	// Helper function for decoding hexadecimal string into a byte array
-	fn decode_hex_to_bytes(hex_str: &str) -> Result<Vec<u8>, EigenError> {
-		hex::decode(&hex_str[2..]).map_err(|e| EigenError::ParsingError(e.to_string()))
-	}
+/// Converts a hex string to a 20 byte array.
+pub fn str_to_20_byte_array(hex: &str) -> Result<[u8; 20], EigenError> {
+	H160::from_str(hex)
+		.map(|bytes| *bytes.as_fixed_bytes())
+		.map_err(|e| EigenError::ConversionError(e.to_string()))
+}
 
-	// Helper function for encoding byte array into hexadecimal string
-	fn encode_bytes_to_hex(bytes: &[u8]) -> String {
-		format!("0x{}", hex::encode(bytes))
-	}
-
-	// Helper function for parsing string into a byte array
-	fn parse_bytes32(hex_str: &str) -> Result<[u8; 32], EigenError> {
-		let bytes = Self::decode_hex_to_bytes(hex_str)?;
-		let bytes_array: [u8; 32] = bytes.try_into().map_err(|_| {
-			EigenError::ConversionError("Failed to convert into byte array".to_string())
-		})?;
-		Ok(bytes_array)
-	}
-
-	// Helper function for parsing string into a byte array
-	fn parse_bytes20(hex_str: &str) -> Result<[u8; 20], EigenError> {
-		let bytes = Self::decode_hex_to_bytes(hex_str)?;
-		let bytes_array: [u8; 20] = bytes.try_into().map_err(|_| {
-			EigenError::ConversionError("Failed to convert into byte array".to_string())
-		})?;
-		Ok(bytes_array)
-	}
-
-	// Helper function for parsing string into u8
-	fn parse_u8(value: &str) -> Result<u8, EigenError> {
-		value.parse::<u8>().map_err(|e| EigenError::ParsingError(e.to_string()))
-	}
+/// Converts a hex string to a 32 byte array.
+pub fn str_to_32_byte_array(hex: &str) -> Result<[u8; 32], EigenError> {
+	H256::from_str(hex)
+		.map(|bytes| *bytes.as_fixed_bytes())
+		.map_err(|e| EigenError::ConversionError(e.to_string()))
 }
 
 /// The `JSONFileStorage` struct provides a mechanism for persisting


### PR DESCRIPTION
# Description

This PR standardizes the inputs and outputs of the main eigentrust library methods to have a more raw interface in order to avoid unnecessary pre/post processing for the data.

## Related Issues

- Resolves #308 

## Changes

- Remove unused rand crate from the main lib.
- Implement conversions from the contract logs to raw data structs.
- Update storage and cli to handle new data types.
- Fix tests.