### PR TITLE
feat: native threshold circuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "eigentrust-zk",
  "ethers",
  "log",
+ "num-rational",
  "rand",
  "serde",
  "serde_json",

--- a/eigentrust/Cargo.toml
+++ b/eigentrust/Cargo.toml
@@ -11,6 +11,7 @@ csv = "1.1"
 ethers = "2.0.8"
 log = "0.4.19"
 rand = "0.8"
+num-rational = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.43"


### PR DESCRIPTION
# Description

This PR aims removes the comparison check for the bandada group score threshold from the `cli` crate and implements the `Threshold` circuit to verify the score value.


## Related Issues

- #345 

## Changes

- Add `num_rational` dependency to the `eigentrust` lib to create a `BigRational`.
- Parse the score values loaded from the file and implement the native `Threshold` circuit to validate the score.
