### PR TITLE
feat(lib): attestation filtering

### DIFF
--- a/eigentrust/src/attestation.rs
+++ b/eigentrust/src/attestation.rs
@@ -533,6 +533,16 @@ impl From<SignedAttestationEth> for SignedAttestationRaw {
 	}
 }
 
+/// Builds the attestation default key for the given domain.
+pub fn build_att_key(domain: H160) -> H256 {
+	let mut key = [0; 32];
+
+	key[..DOMAIN_PREFIX_LEN].copy_from_slice(&DOMAIN_PREFIX);
+	key[DOMAIN_PREFIX_LEN..].copy_from_slice(domain.as_fixed_bytes());
+
+	H256::from(key)
+}
+
 #[cfg(test)]
 mod tests {
 	use crate::att_station::AttestationData as ContractAttestationData;

--- a/eigentrust/src/lib.rs
+++ b/eigentrust/src/lib.rs
@@ -466,21 +466,17 @@ impl Client {
 			self.config.as_address.parse::<Address>().unwrap(),
 			self.get_signer(),
 		);
-		let filter = as_contract.attestation_created_filter().filter.from_block(0);
 		let domain = H160::from(str_to_20_byte_array(&self.config.domain)?);
 
+		// Set filter
+		let filter = as_contract
+			.attestation_created_filter()
+			.filter
+			.topic3(build_att_key(domain))
+			.from_block(0);
+
 		// Fetch logs matching the filter.
-		let logs = self
-			.signer
-			.get_logs(&filter)
-			.await
-			.map_err(|e| EigenError::ParsingError(e.to_string()))?;
-
-		// Filter logs based on the correct key.
-		let filtered_logs: Vec<Log> =
-			logs.iter().filter(|log| log.topics[3] == build_att_key(domain)).cloned().collect();
-
-		Ok(filtered_logs)
+		self.signer.get_logs(&filter).await.map_err(|e| EigenError::ParsingError(e.to_string()))
 	}
 
 	/// Verifies the given proof.


### PR DESCRIPTION
# Description

This PR introduces changes to filter the attestations retrieved from the contract, in order to only process the ones belonging to the an EigenTrust related project and also to the configured domain.

## Related Issues

- Resolves #353 

## Changes

- Update get_logs library method.
- Add test for get_logs.