### PR TITLE
feat(lib): threshold circuit integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 
 # Assets
 /eigentrust-cli/assets/attestation_station.rs
-/eigentrust-cli/assets/et-proving-key.bin
-/eigentrust-cli/assets/et-public-inputs.bin
-/eigentrust-cli/assets/et-proof.bin
+/eigentrust-cli/assets/*-proving-key.bin
+/eigentrust-cli/assets/*-public-inputs.bin
+/eigentrust-cli/assets/*-proof.bin
 /eigentrust-cli/assets/kzg-params-*.bin

--- a/eigentrust-cli/src/cli.rs
+++ b/eigentrust-cli/src/cli.rs
@@ -10,7 +10,7 @@ use crate::{
 use clap::{Args, Parser, Subcommand};
 use eigentrust::{
 	attestation::{AttestationRaw, SignedAttestationRaw},
-	circuit::ET_PARAMS_K,
+	circuit::{Circuit, ET_PARAMS_K, TH_PARAMS_K},
 	error::EigenError,
 	eth::deploy_as,
 	storage::{
@@ -53,6 +53,12 @@ pub enum Mode {
 	LocalScores,
 	/// Retrieves and saves all attestations and calculates the global scores.
 	Scores,
+	/// Generates a Threshold circuit proof for the selected participant.
+	ThProof(ThProofData),
+	/// Generates EigenTrust circuit proving key
+	ThProvingKey,
+	/// Verifies the stored threshold circuit proof.
+	ThVerify,
 	/// Displays the current configuration.
 	Show,
 	/// Updates the configuration. Requires 'UpdateData'.
@@ -113,12 +119,20 @@ pub struct UpdateData {
 	node_url: Option<String>,
 }
 
-/// KZGParams subcommand inputs
+/// KZGParams subcommand input.
 #[derive(Args, Debug)]
 pub struct KZGParamsData {
 	/// Polynomial degree.
 	#[clap(long = "k")]
 	k: Option<String>,
+}
+
+/// ThresholdProof subcommand input.
+#[derive(Args, Debug)]
+pub struct ThProofData {
+	/// Peer.
+	#[clap(long = "peer")]
+	peer: Option<String>,
 }
 
 /// Bandada API action.
@@ -298,12 +312,12 @@ pub async fn handle_deploy(config: ClientConfig) -> Result<(), EigenError> {
 	Ok(())
 }
 
-/// Handles proving key generation.
+/// Handles eigentrust circuit proving key generation.
 pub fn handle_et_pk() -> Result<(), EigenError> {
 	let et_kzg_params = EigenFile::KzgParams(ET_PARAMS_K).load()?;
 	let proving_key = Client::generate_et_pk(et_kzg_params)?;
 
-	EigenFile::ProvingKey.save(proving_key)
+	EigenFile::ProvingKey(Circuit::EigenTrust).save(proving_key)
 }
 
 /// Handles the eigentrust proof generation command.
@@ -318,14 +332,14 @@ pub async fn handle_et_proof(config: ClientConfig) -> Result<(), EigenError> {
 	let attestations: Result<Vec<SignedAttestationRaw>, EigenError> =
 		att_storage.load()?.into_iter().map(|record| record.try_into()).collect();
 
-	let proving_key = EigenFile::ProvingKey.load()?;
+	let proving_key = EigenFile::ProvingKey(Circuit::EigenTrust).load()?;
 	let kzg_params = EigenFile::KzgParams(ET_PARAMS_K).load()?;
 
 	// Generate proof
-	let report = client.calculate_scores(attestations?, kzg_params, proving_key).await?;
+	let report = client.calculate_scores(attestations?, kzg_params, proving_key)?;
 
-	EigenFile::EtProof.save(report.proof)?;
-	EigenFile::ETPublicInputs.save(report.pub_inputs.to_bytes())?;
+	EigenFile::Proof(Circuit::EigenTrust).save(report.proof)?;
+	EigenFile::PublicInputs(Circuit::EigenTrust).save(report.pub_inputs.to_bytes())?;
 
 	Ok(())
 }
@@ -337,12 +351,12 @@ pub async fn handle_et_verify(config: ClientConfig) -> Result<(), EigenError> {
 
 	// Load data
 	let kzg_params = EigenFile::KzgParams(ET_PARAMS_K).load()?;
-	let public_inputs = EigenFile::ETPublicInputs.load()?;
-	let proving_key = EigenFile::ProvingKey.load()?;
-	let proof = EigenFile::EtProof.load()?;
+	let public_inputs = EigenFile::PublicInputs(Circuit::EigenTrust).load()?;
+	let proving_key = EigenFile::ProvingKey(Circuit::EigenTrust).load()?;
+	let proof = EigenFile::Proof(Circuit::EigenTrust).load()?;
 
 	// Verify proof
-	client.verify(kzg_params, public_inputs, proving_key, proof).await?;
+	client.verify(kzg_params, public_inputs, proving_key, proof)?;
 
 	info!("EigenTrust proof has been verified.");
 	Ok(())
@@ -402,13 +416,12 @@ pub async fn handle_scores(
 		},
 	};
 
-	let proving_key = EigenFile::ProvingKey.load()?;
+	let proving_key = EigenFile::ProvingKey(Circuit::EigenTrust).load()?;
 	let kzg_params = EigenFile::KzgParams(ET_PARAMS_K).load()?;
 
 	// Calculate scores
 	let score_records: Vec<ScoreRecord> = client
-		.calculate_scores(attestations, kzg_params, proving_key)
-		.await?
+		.calculate_scores(attestations, kzg_params, proving_key)?
 		.scores
 		.into_iter()
 		.map(ScoreRecord::from_score)
@@ -426,6 +439,87 @@ pub async fn handle_scores(
 		records_storage.filepath().display()
 	);
 
+	Ok(())
+}
+
+/// Handles threshold circuit proving key generation.
+pub async fn handle_th_pk(config: ClientConfig) -> Result<(), EigenError> {
+	let mnemonic = load_mnemonic();
+	let client = Client::new(config, mnemonic);
+
+	// Load KZG params
+	let et_kzg_params = EigenFile::KzgParams(ET_PARAMS_K).load()?;
+	let th_kzg_params = EigenFile::KzgParams(TH_PARAMS_K).load()?;
+
+	// Get attestations
+	let att_fp = get_file_path("attestations", FileType::Csv)?;
+	handle_attestations(client.get_config().clone()).await?;
+	let att_storage = CSVFileStorage::<AttestationRecord>::new(att_fp);
+	let attestations: Result<Vec<SignedAttestationRaw>, EigenError> =
+		att_storage.load()?.into_iter().map(|record| record.try_into()).collect();
+
+	let proving_key = client.generate_th_pk(attestations?, et_kzg_params, th_kzg_params)?;
+
+	EigenFile::ProvingKey(Circuit::Threshold).save(proving_key)
+}
+
+/// Handles threshold circuit proof generation.
+pub async fn handle_th_proof(config: ClientConfig, data: ThProofData) -> Result<(), EigenError> {
+	let mnemonic = load_mnemonic();
+	let client = Client::new(config.clone(), mnemonic);
+
+	// Load KZG params and proving key
+	let et_kzg_params = EigenFile::KzgParams(ET_PARAMS_K).load()?;
+	let th_kzg_params = EigenFile::KzgParams(TH_PARAMS_K).load()?;
+	let proving_key = EigenFile::ProvingKey(Circuit::Threshold).load()?;
+
+	// Get attestations
+	let att_fp = get_file_path("attestations", FileType::Csv)?;
+	handle_attestations(client.get_config().clone()).await?;
+	let att_storage = CSVFileStorage::<AttestationRecord>::new(att_fp);
+	let attestations: Result<Vec<SignedAttestationRaw>, EigenError> =
+		att_storage.load()?.into_iter().map(|record| record.try_into()).collect();
+
+	// Parse peer id
+	let peer_id = match data.peer {
+		Some(peer) => peer.parse::<u32>().map_err(|e| EigenError::ParsingError(e.to_string()))?,
+		None => {
+			return Err(EigenError::ValidationError(
+				"Missing parameter 'peer': participant address.".to_string(),
+			))
+		},
+	};
+
+	let report = client.generate_th_proof(
+		attestations?,
+		et_kzg_params,
+		th_kzg_params,
+		proving_key,
+		config.band_th.parse().unwrap(),
+		peer_id,
+	)?;
+
+	EigenFile::Proof(Circuit::Threshold).save(report.proof)?;
+	EigenFile::PublicInputs(Circuit::Threshold).save(report.pub_inputs.to_bytes())?;
+
+	Ok(())
+}
+
+/// Handles the eigentrust proof verification command.
+pub async fn handle_th_verify(config: ClientConfig) -> Result<(), EigenError> {
+	let mnemonic = load_mnemonic();
+	let client = Client::new(config, mnemonic);
+
+	// Load data
+	let kzg_params = EigenFile::KzgParams(TH_PARAMS_K).load()?;
+	let public_inputs = EigenFile::PublicInputs(Circuit::Threshold).load()?;
+	let proving_key = EigenFile::ProvingKey(Circuit::Threshold).load()?;
+	let proof = EigenFile::Proof(Circuit::Threshold).load()?;
+
+	// Verify proof
+	client.verify(kzg_params, public_inputs, proving_key, proof)?;
+
+	info!("Threshold proof has been verified.");
 	Ok(())
 }
 

--- a/eigentrust-cli/src/cli.rs
+++ b/eigentrust-cli/src/cli.rs
@@ -55,9 +55,9 @@ pub enum Mode {
 	Scores,
 	/// Generates a Threshold circuit proof for the selected participant.
 	ThProof(ThProofData),
-	/// Generates EigenTrust circuit proving key
+	/// Generates Threshold circuit proving key
 	ThProvingKey,
-	/// Verifies the stored threshold circuit proof.
+	/// Verifies the stored Threshold circuit proof.
 	ThVerify,
 	/// Displays the current configuration.
 	Show,

--- a/eigentrust-cli/src/fs.rs
+++ b/eigentrust-cli/src/fs.rs
@@ -4,6 +4,7 @@
 
 use dotenv::{dotenv, var};
 use eigentrust::{
+	circuit::Circuit,
 	error::EigenError,
 	storage::{BinFileStorage, JSONFileStorage, Storage},
 	ClientConfig,
@@ -15,12 +16,12 @@ use std::{env::current_dir, path::PathBuf};
 const DEFAULT_MNEMONIC: &str = "test test test test test test test test test test test junk";
 /// Library configuration file name.
 pub const CONFIG_FILE: &str = "config";
-/// EigenTrust generated proof file name.
-pub const ET_PROOF_FILE: &str = "et-proof";
-/// EigenTrust proving key file name.
-pub const ET_PROVING_KEY_FILE: &str = "et-proving-key";
-/// EigenTrust proof public inputs file name.
-pub const ET_PUB_INP_FILE: &str = "et-public-inputs";
+/// Proof file name.
+pub const PROOF_FILE: &str = "proof";
+/// Proving key file name.
+pub const PROVING_KEY_FILE: &str = "proving-key";
+/// Public inputs file name.
+pub const PUB_INP_FILE: &str = "public-inputs";
 /// KZG parameters file name.
 pub const PARAMS_FILE: &str = "kzg-params";
 
@@ -48,9 +49,9 @@ impl FileType {
 // Enum for different EigenTrust binary files
 pub enum EigenFile {
 	KzgParams(u32),
-	ProvingKey,
-	EtProof,
-	ETPublicInputs,
+	ProvingKey(Circuit),
+	Proof(Circuit),
+	PublicInputs(Circuit),
 }
 
 impl EigenFile {
@@ -75,9 +76,9 @@ impl EigenFile {
 	fn filename(&self) -> String {
 		match self {
 			EigenFile::KzgParams(pol_degree) => format!("{}-{}", PARAMS_FILE, pol_degree),
-			EigenFile::ProvingKey => ET_PROVING_KEY_FILE.to_string(),
-			EigenFile::EtProof => ET_PROOF_FILE.to_string(),
-			EigenFile::ETPublicInputs => ET_PUB_INP_FILE.to_string(),
+			EigenFile::ProvingKey(circuit) => format!("{}-{}", circuit.as_str(), PROVING_KEY_FILE),
+			EigenFile::Proof(circuit) => format!("{}-{}", circuit.as_str(), PROOF_FILE),
+			EigenFile::PublicInputs(circuit) => format!("{}-{}", circuit.as_str(), PUB_INP_FILE),
 		}
 	}
 }

--- a/eigentrust-cli/src/main.rs
+++ b/eigentrust-cli/src/main.rs
@@ -54,6 +54,9 @@ async fn main() -> Result<(), EigenError> {
 		Mode::LocalScores => handle_scores(config, AttestationsOrigin::Local).await?,
 		Mode::Scores => handle_scores(config, AttestationsOrigin::Fetch).await?,
 		Mode::Show => info!("Client config:\n{:#?}", config),
+		Mode::ThProof(data) => handle_th_proof(config, data).await?,
+		Mode::ThProvingKey => handle_th_pk(config).await?,
+		Mode::ThVerify => handle_th_verify(config).await?,
 		Mode::Update(update_data) => handle_update(&mut config, update_data)?,
 	};
 

--- a/eigentrust-zk/src/circuits/dynamic_sets/mod.rs
+++ b/eigentrust-zk/src/circuits/dynamic_sets/mod.rs
@@ -156,7 +156,7 @@ where
 			unassigned_msg_hashes.push(msg_hashes_row);
 			unassigned_s_invs.push(s_inv_row);
 
-			let pk = pks[i].clone().unwrap();
+			let pk = pks[i].clone().unwrap_or(PublicKey::default());
 			let unassigned_pk = UnassignedPublicKey::new(pk);
 			unassigned_pks.push(unassigned_pk);
 		}

--- a/eigentrust-zk/src/circuits/mod.rs
+++ b/eigentrust-zk/src/circuits/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 		sponge::StatefulSpongeChipset,
 		FullRoundChip, PartialRoundChip, PoseidonChipset,
 	},
+	verifier::aggregator::native::NativeAggregator,
 };
 use halo2::halo2curves::{
 	bn256::{Bn256, Fr as Scalar},
@@ -54,6 +55,8 @@ pub const NUM_DECIMAL_LIMBS: usize = 2;
 pub const POWER_OF_TEN: usize = 72;
 /// Default polynomial degree for KZG parameters for EigenTrust circuit.
 pub const ET_PARAMS_K: u32 = 20;
+/// Default polynomial degree for KZG parameters for Threshold circuit.
+pub const TH_PARAMS_K: u32 = 21;
 
 /// Rational score
 pub type RationalScore = BigRational;
@@ -93,6 +96,15 @@ pub type Opinion4 = Opinion<
 	Secp256k1Params,
 	PoseidonNativeHasher,
 	PoseidonNativeSponge,
+>;
+/// Native Aggregator for set with 4 participants
+pub type NativeAggregator4 = NativeAggregator<
+	Bn256,
+	NUM_NEIGHBOURS,
+	NUM_BITS,
+	Bn256_4_68,
+	PoseidonNativeSponge,
+	Bn254Params,
 >;
 
 /// Native EigenTrust set with 4 participants

--- a/eigentrust-zk/src/utils.rs
+++ b/eigentrust-zk/src/utils.rs
@@ -329,11 +329,7 @@ pub fn fe_to_big<F: FieldExt>(fe: F) -> BigUint {
 }
 
 /// Converts a `BigRational` into scaled, decomposed numerator and denominator arrays of field elements.
-pub fn big_to_fe_rat<
-	F: FieldExt,
-	const NUM_DECIMAL_LIMBS: usize,
-	const POWER_OF_TEN: usize,
->(
+pub fn big_to_fe_rat<F: FieldExt, const NUM_DECIMAL_LIMBS: usize, const POWER_OF_TEN: usize>(
 	ratio: BigRational,
 ) -> ([F; NUM_DECIMAL_LIMBS], [F; NUM_DECIMAL_LIMBS]) {
 	let num = ratio.numer();

--- a/eigentrust-zk/src/utils.rs
+++ b/eigentrust-zk/src/utils.rs
@@ -1,6 +1,6 @@
 //! Helper functions for generating params, pk/vk pairs, creating and verifying
 //! proofs, etc.
-use crate::FieldExt;
+use crate::{params::rns::decompose_big_decimal, FieldExt};
 use halo2::{
 	circuit::{AssignedCell, Value},
 	halo2curves::{
@@ -24,7 +24,8 @@ use halo2::{
 		Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
 	},
 };
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
+use num_rational::BigRational;
 use num_traits::{Num, One};
 use rand::Rng;
 use std::{
@@ -325,4 +326,33 @@ pub fn big_to_fe<F: FieldExt>(e: BigUint) -> F {
 /// Returns [`BigUint`] representation for the given [`FieldExt`].
 pub fn fe_to_big<F: FieldExt>(fe: F) -> BigUint {
 	BigUint::from_bytes_le(fe.to_repr().as_ref())
+}
+
+/// Converts a `BigRational` into scaled, decomposed numerator and denominator arrays of field elements.
+pub fn big_to_fe_rat<
+	F: FieldExt,
+	const NUM_DECIMAL_LIMBS: usize,
+	const POWER_OF_TEN: usize,
+>(
+	ratio: BigRational,
+) -> ([F; NUM_DECIMAL_LIMBS], [F; NUM_DECIMAL_LIMBS]) {
+	let num = ratio.numer();
+	let den = ratio.denom();
+	let max_len = NUM_DECIMAL_LIMBS * POWER_OF_TEN;
+	let bigger = num.max(den);
+	let dig_len = bigger.to_string().len();
+	let diff = max_len - dig_len;
+
+	let scale = BigInt::from(10_u32).pow(diff as u32);
+	let num_scaled = num * scale.clone();
+	let den_scaled = den * scale;
+	let num_scaled_uint = num_scaled.to_biguint().unwrap();
+	let den_scaled_uint = den_scaled.to_biguint().unwrap();
+
+	let num_decomposed =
+		decompose_big_decimal::<F, NUM_DECIMAL_LIMBS, POWER_OF_TEN>(num_scaled_uint);
+	let den_decomposed =
+		decompose_big_decimal::<F, NUM_DECIMAL_LIMBS, POWER_OF_TEN>(den_scaled_uint);
+
+	(num_decomposed, den_decomposed)
 }

--- a/eigentrust/src/circuit.rs
+++ b/eigentrust/src/circuit.rs
@@ -3,15 +3,37 @@
 //! This module provides types and utilities for the circuits.
 
 use crate::{attestation::SignedAttestationScalar, error::EigenError};
-use eigentrust_zk::halo2::halo2curves::bn256::Fr as Scalar;
+use eigentrust_zk::{
+	circuits::{ECDSAPublicKey, RationalScore, Threshold4},
+	halo2::halo2curves::bn256::Fr as Scalar,
+};
+use ethers::types::Address;
 
-/// Re export eigentrust KZG params constant
-pub use eigentrust_zk::circuits::ET_PARAMS_K;
+// Re export eigentrust and threshold KZG params constants.
+pub use eigentrust_zk::circuits::{ET_PARAMS_K, TH_PARAMS_K};
 
 /// Scalar length in bytes.
 pub const SCALAR_LEN: usize = 32;
 /// Outbound local trust vector.
 pub type OpinionVector = Vec<Option<SignedAttestationScalar>>;
+
+/// Circuits.
+pub enum Circuit {
+	/// Eigentrust circuit
+	EigenTrust,
+	/// Threshold circuit
+	Threshold,
+}
+
+impl Circuit {
+	/// Converts to static string.
+	pub fn as_str(&self) -> &'static str {
+		match self {
+			Circuit::EigenTrust => "et",
+			Circuit::Threshold => "th",
+		}
+	}
+}
 
 /// Scores report struct.
 pub struct ScoresReport {
@@ -33,6 +55,31 @@ pub struct Score {
 	pub score_rat: ([u8; 32], [u8; 32]),
 	/// Hexadecimal score.
 	pub score_hex: [u8; 32],
+}
+
+/// EigenTrust circuit setup parameters
+pub struct ETSetup {
+	/// Ethereum addresses set.
+	pub address_set: Vec<Address>,
+	/// Attestation matrix.
+	pub attestation_matrix: Vec<Vec<Option<SignedAttestationScalar>>>,
+	/// ECDSA public keys set.
+	pub ecdsa_set: Vec<Option<ECDSAPublicKey>>,
+	/// Public inputs.
+	pub pub_inputs: ETPublicInputs,
+	/// Rational scores.
+	pub rational_scores: Vec<RationalScore>,
+}
+
+impl ETSetup {
+	/// Constructs a new ETSetup instance.
+	pub fn new(
+		address_set: Vec<Address>, attestation_matrix: Vec<Vec<Option<SignedAttestationScalar>>>,
+		ecdsa_set: Vec<Option<ECDSAPublicKey>>, pub_inputs: ETPublicInputs,
+		rational_scores: Vec<RationalScore>,
+	) -> Self {
+		Self { address_set, attestation_matrix, ecdsa_set, pub_inputs, rational_scores }
+	}
 }
 
 /// Eigentrust circuit public input parameters
@@ -87,44 +134,128 @@ impl ETPublicInputs {
 		}
 
 		// Build participants.
-		let participants_vec = (0..participants)
-			.map(|i| Self::get_scalar_at(&bytes, i))
-			.collect::<Result<Vec<_>, _>>()?;
+		let participants_vec =
+			(0..participants).map(|i| get_scalar_at(&bytes, i)).collect::<Result<Vec<_>, _>>()?;
 
 		// Build scores.
 		let scores_vec = (participants..2 * participants)
-			.map(|i| Self::get_scalar_at(&bytes, i))
+			.map(|i| get_scalar_at(&bytes, i))
 			.collect::<Result<Vec<_>, _>>()?;
 
 		// Build domain and opinion hash.
-		let domain = Self::get_scalar_at(&bytes, 2 * participants)?;
-		let opinion_hash = Self::get_scalar_at(&bytes, 2 * participants + 1)?;
+		let domain = get_scalar_at(&bytes, 2 * participants)?;
+		let opinion_hash = get_scalar_at(&bytes, 2 * participants + 1)?;
 
 		Ok(Self::new(
 			participants_vec, scores_vec, domain, opinion_hash,
 		))
 	}
+}
 
-	/// Gets a Scalar from a byte slice at a given index.
-	fn get_scalar_at(bytes: &[u8], index: usize) -> Result<Scalar, EigenError> {
-		let start = index * SCALAR_LEN;
-		let slice = &bytes[start..start + SCALAR_LEN];
+/// Threshold circuit setup parameters.
+pub struct ThSetup {
+	/// Threshold circuit.
+	pub circuit: Threshold4,
+	/// Public inputs.
+	pub pub_inputs: ThPublicInputs,
+}
 
-		// Convert the slice into an array reference
-		let array_ref: &[u8; 32] = slice.try_into().map_err(|_| {
-			EigenError::ParsingError("Failed to convert slice into array".to_string())
-		})?;
+impl ThSetup {
+	/// Creates a new ThSetup instance.
+	pub fn new(circuit: Threshold4, pub_inputs: ThPublicInputs) -> Self {
+		Self { circuit, pub_inputs }
+	}
+}
 
-		// Convert bytes into a scalar
-		let scalar_opt = Scalar::from_bytes(array_ref);
+/// Threshold circuit report.
+pub struct ThReport {
+	/// Proof.
+	pub proof: Vec<u8>,
+	/// Verifier public inputs.
+	pub pub_inputs: ThPublicInputs,
+}
 
-		if scalar_opt.is_some().into() {
-			Ok(scalar_opt.unwrap())
-		} else {
-			Err(EigenError::ParsingError(
-				"Failed to construct scalar from bytes".to_string(),
-			))
+/// Threshold circuit public input parameters.
+pub struct ThPublicInputs {
+	/// Participant address.
+	pub address: Scalar,
+	/// Threshold value.
+	pub threshold: Scalar,
+	/// Native threshold check.
+	pub th_check: Scalar,
+	/// Native aggregator instances.
+	pub instances: Vec<Scalar>,
+}
+
+impl ThPublicInputs {
+	/// Creates a new ThPublicInputs instance.
+	pub fn new(
+		address: Scalar, threshold: Scalar, th_check: Scalar, instances: Vec<Scalar>,
+	) -> Self {
+		Self { address, threshold, th_check, instances }
+	}
+
+	/// Returns the struct as a concatenated Vec<Scalar>.
+	pub fn to_vec(&self) -> Vec<Scalar> {
+		let mut result = Vec::new();
+		result.push(self.address);
+		result.push(self.threshold);
+		result.push(self.th_check);
+		result.extend(self.instances.iter().cloned());
+
+		result
+	}
+
+	/// Returns the struct as a concatenated Vec<u8>.
+	pub fn to_bytes(&self) -> Vec<u8> {
+		let mut result = Vec::new();
+		result.extend(self.address.to_bytes());
+		result.extend(self.threshold.to_bytes());
+		result.extend(self.th_check.to_bytes());
+		result.extend(self.instances.iter().flat_map(|s| s.to_bytes()));
+
+		result
+	}
+
+	/// Creates a new ThPublicInputs instance from a Vec<u8>.
+	pub fn from_bytes(bytes: Vec<u8>, instances_count: usize) -> Result<Self, EigenError> {
+		if bytes.len() != (instances_count + 3) * SCALAR_LEN {
+			return Err(EigenError::ParsingError(
+				"Invalid bytes length.".to_string(),
+			));
 		}
+
+		let address = get_scalar_at(&bytes, 0)?;
+		let threshold = get_scalar_at(&bytes, 1)?;
+		let th_check = get_scalar_at(&bytes, 2)?;
+
+		let instances_vec = (3..3 + instances_count)
+			.map(|i| get_scalar_at(&bytes, i))
+			.collect::<Result<Vec<_>, _>>()?;
+
+		Ok(Self::new(address, threshold, th_check, instances_vec))
+	}
+}
+
+/// Gets a Scalar from a byte slice at a given index.
+fn get_scalar_at(bytes: &[u8], index: usize) -> Result<Scalar, EigenError> {
+	let start = index * SCALAR_LEN;
+	let slice = &bytes[start..start + SCALAR_LEN];
+
+	// Convert the slice into an array reference
+	let array_ref: &[u8; 32] = slice
+		.try_into()
+		.map_err(|_| EigenError::ParsingError("Failed to convert slice into array".to_string()))?;
+
+	// Convert bytes into a scalar
+	let scalar_opt = Scalar::from_bytes(array_ref);
+
+	if scalar_opt.is_some().into() {
+		Ok(scalar_opt.unwrap())
+	} else {
+		Err(EigenError::ParsingError(
+			"Failed to construct scalar from bytes".to_string(),
+		))
 	}
 }
 
@@ -255,6 +386,111 @@ mod tests {
 		let invalid_bytes = vec![0u8; 128];
 
 		let result = ETPublicInputs::from_bytes(invalid_bytes, 2);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_th_public_inputs_new() {
+		let scalar = Scalar::random(&mut rand::thread_rng());
+
+		let inputs = ThPublicInputs::new(
+			scalar.clone(),
+			scalar.clone(),
+			scalar.clone(),
+			vec![scalar.clone(), scalar.clone()],
+		);
+
+		assert_eq!(inputs.instances.len(), 2);
+	}
+
+	#[test]
+	fn test_th_public_inputs_to_vec() {
+		let scalar = Scalar::random(&mut rand::thread_rng());
+		let inputs = ThPublicInputs::new(
+			scalar.clone(),
+			scalar.clone(),
+			scalar.clone(),
+			vec![scalar.clone(), scalar.clone()],
+		);
+
+		let vec_representation = inputs.to_vec();
+
+		assert_eq!(vec_representation.len(), 5);
+		assert_eq!(vec_representation[0], scalar);
+		assert_eq!(vec_representation[1], scalar);
+		assert_eq!(vec_representation[2], scalar);
+		assert_eq!(vec_representation[3], scalar);
+		assert_eq!(vec_representation[4], scalar);
+	}
+
+	#[test]
+	fn test_th_public_inputs_to_bytes() {
+		let scalar = Scalar::random(&mut rand::thread_rng());
+		let inputs = ThPublicInputs::new(
+			scalar.clone(),
+			scalar.clone(),
+			scalar.clone(),
+			vec![scalar.clone(), scalar.clone()],
+		);
+
+		let bytes_representation = inputs.to_bytes();
+
+		assert_eq!(bytes_representation.len(), 5 * 32);
+	}
+
+	#[test]
+	fn test_th_public_inputs_from_bytes() {
+		let scalar = Scalar::random(&mut rand::thread_rng());
+		let inputs = ThPublicInputs::new(
+			scalar.clone(),
+			scalar.clone(),
+			scalar.clone(),
+			vec![scalar.clone(), scalar.clone()],
+		);
+
+		let bytes_representation = inputs.to_bytes();
+		let reconstructed_inputs = ThPublicInputs::from_bytes(bytes_representation, 2).unwrap();
+
+		assert_eq!(inputs.address, reconstructed_inputs.address);
+		assert_eq!(inputs.threshold, reconstructed_inputs.threshold);
+		assert_eq!(inputs.th_check, reconstructed_inputs.th_check);
+		assert_eq!(inputs.instances, reconstructed_inputs.instances);
+	}
+
+	#[test]
+	fn test_invalid_byte_length_th() {
+		let scalar = Scalar::random(&mut rand::thread_rng());
+		let inputs = ThPublicInputs::new(
+			scalar.clone(),
+			scalar.clone(),
+			scalar.clone(),
+			vec![scalar.clone(), scalar.clone()],
+		);
+		let mut bytes_representation = inputs.to_bytes();
+
+		// Remove some bytes to make it invalid
+		bytes_representation.pop();
+
+		let result = ThPublicInputs::from_bytes(bytes_representation, 2);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_empty_instances() {
+		let scalar = Scalar::random(&mut rand::thread_rng());
+		let inputs = ThPublicInputs::new(scalar.clone(), scalar.clone(), scalar.clone(), vec![]);
+
+		let bytes_representation = inputs.to_bytes();
+		let reconstructed_inputs = ThPublicInputs::from_bytes(bytes_representation, 0).unwrap();
+
+		assert!(reconstructed_inputs.instances.is_empty());
+	}
+
+	#[test]
+	fn test_invalid_scalar_byte_construction_th() {
+		let invalid_bytes = vec![0u8; 128];
+
+		let result = ThPublicInputs::from_bytes(invalid_bytes, 4);
 		assert!(result.is_err());
 	}
 }

--- a/eigentrust/src/circuit.rs
+++ b/eigentrust/src/circuit.rs
@@ -35,10 +35,8 @@ impl Circuit {
 	}
 }
 
-/// Scores report struct.
-pub struct ScoresReport {
-	/// Participants' scores
-	pub scores: Vec<Score>,
+/// EigenTrust report struct.
+pub struct ETReport {
 	/// Verifier public inputs
 	pub pub_inputs: ETPublicInputs,
 	/// Proof

--- a/eigentrust/src/error.rs
+++ b/eigentrust/src/error.rs
@@ -47,6 +47,10 @@ pub enum EigenError {
 	#[error("ParsingError: {0}")]
 	ParsingError(String),
 
+	/// Proving error
+	#[error("ProvingError: {0}")]
+	ProvingError(String),
+
 	/// Read/Write error
 	#[error("ReadWriteError: {0}")]
 	ReadWriteError(String),

--- a/eigentrust/src/lib.rs
+++ b/eigentrust/src/lib.rs
@@ -291,8 +291,7 @@ impl Client {
 		raw_th_kzg_params: Vec<u8>, raw_proving_key: Vec<u8>, threshold: u32, participant_id: u32,
 	) -> Result<ThReport, EigenError> {
 		let rng = &mut thread_rng();
-		let th_setup =
-			self.th_circuit_setup(att, raw_et_kzg_params.clone(), threshold, participant_id)?;
+		let th_setup = self.th_circuit_setup(att, raw_et_kzg_params, threshold, participant_id)?;
 
 		// Build kzg params and proving key
 		let th_kzg_params =
@@ -499,13 +498,13 @@ impl Client {
 		// Extract and prepare participant-specific data
 		let id = participant_id as usize;
 		let p_address = et_setup.pub_inputs.participants[id];
-		let score = et_setup.pub_inputs.scores[id].clone();
+		let score = et_setup.pub_inputs.scores[id];
 		let rational_score = et_setup.rational_scores[id].clone();
 		let (scalar_num, scalar_den) =
 			big_to_fe_rat::<Scalar, NUM_DECIMAL_LIMBS, POWER_OF_TEN>(rational_score.clone());
 
 		// Check native threshold circuit
-		let scalar_th = Scalar::from(threshold as u64);
+		let scalar_th = Scalar::from(u64::from(threshold));
 		let native_th = NativeThreshold4::new(score, rational_score, scalar_th);
 		let native_th_check = if native_th.check_threshold() { Scalar::ONE } else { Scalar::ZERO };
 

--- a/eigentrust/src/lib.rs
+++ b/eigentrust/src/lib.rs
@@ -62,12 +62,12 @@ use att_station::{
 	AttestationCreatedFilter, AttestationData as ContractAttestationData, AttestationStation,
 };
 use attestation::{build_att_key, AttestationEth, AttestationRaw, SignedAttestationRaw};
-use circuit::ScoresReport;
+use circuit::{ETSetup, ScoresReport, ThPublicInputs, ThReport, ThSetup};
 use eigentrust_zk::{
 	circuits::{
-		threshold::native::Threshold, ECDSAPublicKey, EigenTrust4, NativeEigenTrust4,
-		NativeThreshold4, PoseidonNativeSponge, HASHER_WIDTH, MIN_PEER_COUNT, NUM_ITERATIONS,
-		NUM_NEIGHBOURS,
+		threshold::native::Threshold, ECDSAPublicKey, EigenTrust4, NativeAggregator4,
+		NativeEigenTrust4, NativeThreshold4, PoseidonNativeSponge, Threshold4, HASHER_WIDTH,
+		MIN_PEER_COUNT, NUM_DECIMAL_LIMBS, NUM_ITERATIONS, NUM_NEIGHBOURS, POWER_OF_TEN,
 	},
 	halo2::{
 		arithmetic::Field,
@@ -81,7 +81,8 @@ use eigentrust_zk::{
 	},
 	params::hasher::poseidon_bn254_5x5::Params,
 	poseidon::native::Poseidon,
-	utils::{generate_params, keygen, prove, verify},
+	utils::{big_to_fe_rat, generate_params, keygen, prove, verify},
+	verifier::aggregator::native::Snark,
 };
 use error::EigenError;
 use eth::{address_from_ecdsa_key, ecdsa_keypairs_from_mnemonic, scalar_from_address};
@@ -96,6 +97,7 @@ use ethers::{
 };
 use log::{debug, info, warn};
 use num_rational::BigRational;
+use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use std::{
 	collections::{BTreeSet, HashMap},
@@ -157,47 +159,14 @@ impl Client {
 		Self { signer: shared_signer, config, mnemonic }
 	}
 
-	/// Generates new KZG params (Mostly used for testing)
-	pub fn generate_kzg_params(k: u32) -> Result<Vec<u8>, EigenError> {
-		info!("Generating KZG parameters, this may take a while.");
-
-		let start_time = Instant::now();
-		let params = generate_params::<Bn256>(k);
-		let elapsed_time = start_time.elapsed();
-
-		info!("KZG parameters generated.");
-		debug!("KZG parameters generation time: {:?}", elapsed_time);
-
-		let mut buffer: Vec<u8> = Vec::new();
-		params.write(&mut buffer).map_err(|e| {
-			EigenError::ReadWriteError(format!("Failed to write KZG parameters: {}", e))
-		})?;
-
-		Ok(buffer)
+	/// Gets config.
+	pub fn get_config(&self) -> &ClientConfig {
+		&self.config
 	}
 
-	/// Generates new proving key for EigenTrust circuit
-	pub fn generate_et_pk(raw_kzg_params: Vec<u8>) -> Result<Vec<u8>, EigenError> {
-		let rng = &mut rand::thread_rng();
-
-		let opt_att = vec![vec![None; NUM_ITERATIONS]; NUM_ITERATIONS];
-		let opt_pks = vec![None; NUM_ITERATIONS];
-		let domain = Scalar::random(rng);
-		let et = EigenTrust4::new(opt_att, opt_pks, domain);
-
-		let kzg_params = ParamsKZG::<Bn256>::read(&mut raw_kzg_params.as_slice())
-			.map_err(|e| EigenError::ReadWriteError(format!("Failed to read KZG params: {}", e)))?;
-
-		info!("Generating proving key, this may take a while.");
-		let start_time = Instant::now();
-		let proving_key = keygen(&kzg_params, et)
-			.map_err(|_| EigenError::KeygenError("Failed to generate pk/vk pair".to_string()))?;
-		let elapsed_time = start_time.elapsed();
-
-		info!("Proving key generated.");
-		debug!("Proving key generation time: {:?}", elapsed_time);
-
-		Ok(proving_key.to_bytes(SerdeFormat::Processed))
+	/// Gets signer.
+	pub fn get_signer(&self) -> Arc<ClientSigner> {
+		self.signer.clone()
 	}
 
 	/// Submits an attestation to the attestation station.
@@ -255,9 +224,136 @@ impl Client {
 	}
 
 	/// Calculates the EigenTrust global scores.
-	pub async fn calculate_scores(
+	pub fn calculate_scores(
 		&self, att: Vec<SignedAttestationRaw>, raw_kzg_params: Vec<u8>, raw_prov_key: Vec<u8>,
 	) -> Result<ScoresReport, EigenError> {
+		let rng = &mut rand::thread_rng();
+		let et_setup = self.et_circuit_setup(att)?;
+
+		// Parse KZG params and proving key
+		let kzg_params: ParamsKZG<Bn256> =
+			ParamsKZG::<Bn256>::read(&mut raw_kzg_params.as_slice()).unwrap();
+		let proving_key: ProvingKey<G1Affine> =
+			ProvingKey::from_bytes::<EigenTrust4>(&raw_prov_key, SerdeFormat::Processed).unwrap();
+
+		// Construct scores vec
+		let scores: Vec<Score> = et_setup
+			.address_set
+			.iter()
+			.zip(et_setup.pub_inputs.scores.iter())
+			.zip(et_setup.rational_scores.iter())
+			.map(|((&participant, &score_fr), score_rat)| {
+				let address = participant.to_fixed_bytes();
+
+				let mut scalar = score_fr.to_bytes();
+				scalar.reverse();
+
+				let num_bytes = score_rat.numer().to_bytes_be().1;
+				let den_bytes = score_rat.denom().to_bytes_be().1;
+				let score_bytes = score_rat.to_integer().to_bytes_be().1;
+
+				let mut numerator: [u8; 32] = [0; 32];
+				numerator[32 - num_bytes.len()..].copy_from_slice(&num_bytes);
+
+				let mut denominator: [u8; 32] = [0; 32];
+				denominator[32 - den_bytes.len()..].copy_from_slice(&den_bytes);
+
+				let mut score_hex: [u8; 32] = [0; 32];
+				score_hex[32 - score_bytes.len()..].copy_from_slice(&score_bytes);
+
+				Score { address, score_fr: scalar, score_rat: (numerator, denominator), score_hex }
+			})
+			.collect();
+
+		// Initialize EigenTrustSet
+		let et_circuit: EigenTrust4 = EigenTrust4::new(
+			et_setup.attestation_matrix,
+			et_setup.ecdsa_set,
+			self.get_scalar_domain()?,
+		);
+
+		// Generate proof
+		let proof = prove::<Bn256, _, _>(
+			&kzg_params,
+			et_circuit,
+			&[&et_setup.pub_inputs.to_vec()],
+			&proving_key,
+			rng,
+		)
+		.map_err(|e| EigenError::ProvingError(format!("Failed to generate proof: {}", e)))?;
+
+		Ok(ScoresReport { scores, pub_inputs: et_setup.pub_inputs, proof })
+	}
+
+	/// Generates Threshold circuit proof for the selected participant
+	pub fn generate_th_proof(
+		&self, att: Vec<SignedAttestationRaw>, raw_et_kzg_params: Vec<u8>,
+		raw_th_kzg_params: Vec<u8>, raw_proving_key: Vec<u8>, threshold: u32, participant_id: u32,
+	) -> Result<ThReport, EigenError> {
+		let rng = &mut thread_rng();
+		let th_setup =
+			self.th_circuit_setup(att, raw_et_kzg_params.clone(), threshold, participant_id)?;
+
+		// Build kzg params and proving key
+		let th_kzg_params =
+			ParamsKZG::<Bn256>::read(&mut raw_th_kzg_params.as_slice()).map_err(|e| {
+				EigenError::ReadWriteError(format!("Failed to read TH KZG params: {}", e))
+			})?;
+		let proving_key = ProvingKey::<G1Affine>::from_bytes::<Threshold4>(
+			&raw_proving_key,
+			SerdeFormat::Processed,
+		)
+		.map_err(|_| EigenError::ProvingError("Failed to parse proving key".to_string()))?;
+
+		let proof = prove::<Bn256, _, _>(
+			&th_kzg_params,
+			th_setup.circuit,
+			&[&th_setup.pub_inputs.to_vec()],
+			&proving_key,
+			rng,
+		)
+		.map_err(|e| EigenError::ProvingError(format!("Failed to generate proof: {}", e)))?;
+
+		Ok(ThReport { proof, pub_inputs: th_setup.pub_inputs })
+	}
+
+	/// Verifies the given proof.
+	pub fn verify(
+		&self, raw_kzg_params: Vec<u8>, raw_public_inputs: Vec<u8>, raw_proving_key: Vec<u8>,
+		proof: Vec<u8>,
+	) -> Result<(), EigenError> {
+		// Parse KZG params
+		let kzg_params: ParamsKZG<Bn256> = ParamsKZG::read(&mut raw_kzg_params.as_slice())
+			.map_err(|e| EigenError::ParsingError(e.to_string()))?;
+
+		// Parse public inputs
+		let pub_inputs: ETPublicInputs =
+			ETPublicInputs::from_bytes(raw_public_inputs, NUM_NEIGHBOURS)?;
+
+		// Parse proving key
+		let proving_key: ProvingKey<G1Affine> =
+			ProvingKey::from_bytes::<EigenTrust4>(&raw_proving_key, SerdeFormat::Processed)
+				.map_err(|e| EigenError::ParsingError(e.to_string()))?;
+
+		// Verify
+		let is_verified = verify(
+			&kzg_params,
+			&[&pub_inputs.to_vec()],
+			&proof,
+			proving_key.get_vk(),
+		)
+		.map_err(|e| EigenError::VerificationError(e.to_string()));
+
+		match is_verified? {
+			true => Ok(()),
+			false => Err(EigenError::VerificationError(
+				"Verification failed".to_string(),
+			)),
+		}
+	}
+
+	/// Returns a built eigen trust circuit and relevant circuit data.
+	pub fn et_circuit_setup(&self, att: Vec<SignedAttestationRaw>) -> Result<ETSetup, EigenError> {
 		// Get signed attestations
 		let attestations: Vec<SignedAttestationEth> =
 			att.into_iter().map(|signed_raw| signed_raw.into()).collect();
@@ -372,34 +468,6 @@ impl Client {
 			"There are more participants than scores"
 		);
 
-		// Construct scores vec
-		let scores: Vec<Score> = address_set
-			.iter()
-			.zip(scalar_scores.iter())
-			.zip(rational_scores.iter())
-			.map(|((&participant, &score_fr), score_rat)| {
-				let address = participant.to_fixed_bytes();
-
-				let mut scalar = score_fr.to_bytes();
-				scalar.reverse();
-
-				let num_bytes = score_rat.numer().to_bytes_be().1;
-				let den_bytes = score_rat.denom().to_bytes_be().1;
-				let score_bytes = score_rat.to_integer().to_bytes_be().1;
-
-				let mut numerator: [u8; 32] = [0; 32];
-				numerator[32 - num_bytes.len()..].copy_from_slice(&num_bytes);
-
-				let mut denominator: [u8; 32] = [0; 32];
-				denominator[32 - den_bytes.len()..].copy_from_slice(&den_bytes);
-
-				let mut score_hex: [u8; 32] = [0; 32];
-				score_hex[32 - score_bytes.len()..].copy_from_slice(&score_bytes);
-
-				Score { address, score_fr: scalar, score_rat: (numerator, denominator), score_hex }
-			})
-			.collect();
-
 		// Generate opinions' sponge hash.
 		let mut sponge = PoseidonNativeSponge::new();
 		sponge.update(&op_hashes);
@@ -409,29 +477,136 @@ impl Client {
 		let pub_inputs =
 			ETPublicInputs::new(scalar_set, scalar_scores, scalar_domain, opinions_hash);
 
-		// Initialize EigenTrustSet
-		let et_circuit: EigenTrust4 =
-			EigenTrust4::new(attestation_matrix, ecdsa_pub_keys, scalar_domain);
+		Ok(ETSetup::new(
+			address_set, attestation_matrix, ecdsa_pub_keys, pub_inputs, rational_scores,
+		))
+	}
 
-		// Parse KZG params
-		let kzg_params: ParamsKZG<Bn256> =
-			ParamsKZG::<Bn256>::read(&mut raw_kzg_params.as_slice()).unwrap();
+	/// Generates Threshold circuit proof for the selected participant
+	pub fn th_circuit_setup(
+		&self, att: Vec<SignedAttestationRaw>, raw_et_kzg_params: Vec<u8>, threshold: u32,
+		participant_id: u32,
+	) -> Result<ThSetup, EigenError> {
+		let rng = &mut thread_rng();
+		let et_setup = self.et_circuit_setup(att)?;
 
-		// Parse proving key
-		let proving_key: ProvingKey<G1Affine> =
-			ProvingKey::from_bytes::<EigenTrust4>(&raw_prov_key, SerdeFormat::Processed).unwrap();
+		// Build kzg params and proving key
+		let et_kzg_params =
+			ParamsKZG::<Bn256>::read(&mut raw_et_kzg_params.as_slice()).map_err(|e| {
+				EigenError::ReadWriteError(format!("Failed to read ET KZG params: {}", e))
+			})?;
 
-		let rng = &mut rand::thread_rng();
-		let proof = prove::<Bn256, _, _>(
-			&kzg_params,
+		// Extract and prepare participant-specific data
+		let id = participant_id as usize;
+		let p_address = et_setup.pub_inputs.participants[id];
+		let score = et_setup.pub_inputs.scores[id].clone();
+		let rational_score = et_setup.rational_scores[id].clone();
+		let (scalar_num, scalar_den) =
+			big_to_fe_rat::<Scalar, NUM_DECIMAL_LIMBS, POWER_OF_TEN>(rational_score.clone());
+
+		// Check native threshold circuit
+		let scalar_th = Scalar::from(threshold as u64);
+		let native_th = NativeThreshold4::new(score, rational_score, scalar_th);
+		let native_th_check = if native_th.check_threshold() { Scalar::ONE } else { Scalar::ZERO };
+
+		// Setup EigenTrust and Aggregator circuits
+		let et_circuit = EigenTrust4::new(
+			et_setup.attestation_matrix,
+			et_setup.ecdsa_set,
+			self.get_scalar_domain()?,
+		);
+		let snark = Snark::new(
+			&et_kzg_params,
 			et_circuit,
-			&[&pub_inputs.to_vec()],
-			&proving_key,
+			vec![et_setup.pub_inputs.to_vec()],
 			rng,
-		)
-		.unwrap();
+		);
+		let native_agg = NativeAggregator4::new(&et_kzg_params, vec![snark]);
 
-		Ok(ScoresReport { scores, pub_inputs, proof })
+		// Setup Threshold circuit public inputs
+		let th_pub_inp = ThPublicInputs::new(
+			p_address,
+			scalar_th,
+			native_th_check,
+			native_agg.instances.clone(),
+		);
+
+		// Build Threshold circuit
+		let th_circuit = Threshold4::new::<PoseidonNativeSponge>(
+			&et_setup.pub_inputs.participants, &et_setup.pub_inputs.scores, &scalar_num,
+			&scalar_den, native_agg.svk, native_agg.snarks, native_agg.as_proof,
+		);
+
+		Ok(ThSetup::new(th_circuit, th_pub_inp))
+	}
+
+	/// Generates new proving key for EigenTrust circuit
+	pub fn generate_et_pk(raw_kzg_params: Vec<u8>) -> Result<Vec<u8>, EigenError> {
+		let rng = &mut rand::thread_rng();
+
+		let opt_att = vec![vec![None; NUM_ITERATIONS]; NUM_ITERATIONS];
+		let opt_pks = vec![None; NUM_ITERATIONS];
+		let domain = Scalar::random(rng);
+		let et = EigenTrust4::new(opt_att, opt_pks, domain);
+
+		let kzg_params = ParamsKZG::<Bn256>::read(&mut raw_kzg_params.as_slice())
+			.map_err(|e| EigenError::ReadWriteError(format!("Failed to read KZG params: {}", e)))?;
+
+		info!("Generating proving key, this may take a while.");
+		let start_time = Instant::now();
+		let proving_key = keygen(&kzg_params, et)
+			.map_err(|_| EigenError::KeygenError("Failed to generate pk/vk pair".to_string()))?;
+		let elapsed_time = start_time.elapsed();
+
+		info!("Proving key generated.");
+		debug!("Proving key generation time: {:?}", elapsed_time);
+
+		Ok(proving_key.to_bytes(SerdeFormat::Processed))
+	}
+
+	/// Generates new proving key for the Threshold circuit (not working)
+	pub fn generate_th_pk(
+		&self, att: Vec<SignedAttestationRaw>, raw_et_kzg_params: Vec<u8>,
+		raw_th_kzg_params: Vec<u8>,
+	) -> Result<Vec<u8>, EigenError> {
+		let th_kzg_params =
+			ParamsKZG::<Bn256>::read(&mut raw_th_kzg_params.as_slice()).map_err(|e| {
+				EigenError::ReadWriteError(format!("Failed to read TH KZG params: {}", e))
+			})?;
+		let th_setup =
+			self.th_circuit_setup(att, raw_et_kzg_params, u32::default(), u32::default())?;
+
+		info!("Generating proving key, this may take a while.");
+		let start_time = Instant::now();
+
+		let proving_key = keygen(&th_kzg_params, th_setup.circuit).map_err(|e| {
+			EigenError::KeygenError(format!("Failed to generate pk/vk pair: {}", e))
+		})?;
+
+		let elapsed_time = start_time.elapsed();
+		info!("Proving key generated.");
+		debug!("Proving key generation time: {:?}", elapsed_time);
+
+		Ok(proving_key.to_bytes(SerdeFormat::Processed))
+	}
+
+	/// Generates new KZG params (Mostly used for testing)
+	pub fn generate_kzg_params(k: u32) -> Result<Vec<u8>, EigenError> {
+		info!("Generating KZG parameters, this may take a while.");
+
+		let start_time = Instant::now();
+		let params = generate_params::<Bn256>(k);
+		let elapsed_time = start_time.elapsed();
+
+		info!("KZG parameters generated.");
+		debug!("KZG parameters generation time: {:?}", elapsed_time);
+
+		let mut buffer: Vec<u8> = Vec::new();
+		params.write(&mut buffer).map_err(|e| {
+			EigenError::ReadWriteError(format!("Failed to write KZG parameters: {}", e))
+		})?;
+
+		Ok(buffer)
 	}
 
 	/// Fetches attestations from the contract.
@@ -477,51 +652,6 @@ impl Client {
 
 		// Fetch logs matching the filter.
 		self.signer.get_logs(&filter).await.map_err(|e| EigenError::ParsingError(e.to_string()))
-	}
-
-	/// Verifies the given proof.
-	pub async fn verify(
-		&self, raw_kzg_params: Vec<u8>, raw_public_inputs: Vec<u8>, raw_proving_key: Vec<u8>,
-		proof: Vec<u8>,
-	) -> Result<(), EigenError> {
-		// Parse KZG params
-		let kzg_params: ParamsKZG<Bn256> = ParamsKZG::read(&mut raw_kzg_params.as_slice())
-			.map_err(|e| EigenError::ParsingError(e.to_string()))?;
-
-		// Parse public inputs
-		let pub_inputs: ETPublicInputs =
-			ETPublicInputs::from_bytes(raw_public_inputs, NUM_NEIGHBOURS)?;
-
-		// Parse proving key
-		let proving_key: ProvingKey<G1Affine> =
-			ProvingKey::from_bytes::<EigenTrust4>(&raw_proving_key, SerdeFormat::Processed)
-				.map_err(|e| EigenError::ParsingError(e.to_string()))?;
-
-		// Verify
-		let is_verified = verify(
-			&kzg_params,
-			&[&pub_inputs.to_vec()],
-			&proof,
-			proving_key.get_vk(),
-		)
-		.map_err(|e| EigenError::VerificationError(e.to_string()));
-
-		match is_verified? {
-			true => Ok(()),
-			false => Err(EigenError::VerificationError(
-				"Verification failed".to_string(),
-			)),
-		}
-	}
-
-	/// Gets config.
-	pub fn get_config(&self) -> &ClientConfig {
-		&self.config
-	}
-
-	/// Gets signer.
-	pub fn get_signer(&self) -> Arc<ClientSigner> {
-		self.signer.clone()
 	}
 
 	/// Gets the domain as BN256 scalar.

--- a/eigentrust/src/lib.rs
+++ b/eigentrust/src/lib.rs
@@ -668,7 +668,7 @@ impl Client {
 			.map_err(|e| EigenError::ParsingError(format!("Error parsing domain: {}", e)))?;
 		let domain_bytes_256 = H256::from(domain_bytes);
 
-		let mut domain = domain_bytes_256.as_fixed_bytes().clone();
+		let mut domain = *domain_bytes_256.as_fixed_bytes();
 		domain.reverse();
 
 		let domain_opt = Scalar::from_bytes(&domain);

--- a/eigentrust/src/storage.rs
+++ b/eigentrust/src/storage.rs
@@ -12,6 +12,7 @@ use ethers::{
 	types::{H160, H256, U256},
 	utils::hex,
 };
+use log::debug;
 use serde::Deserialize;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{from_reader, to_string};
@@ -164,6 +165,7 @@ impl Storage<Vec<u8>> for BinFileStorage {
 	type Err = EigenError;
 
 	fn load(&self) -> Result<Vec<u8>, Self::Err> {
+		debug!("Loading file: {:?}", &self.filepath);
 		let mut file = File::open(&self.filepath).map_err(EigenError::IOError)?;
 		let mut data = Vec::new();
 		file.read_to_end(&mut data).map_err(EigenError::IOError)?;
@@ -171,6 +173,7 @@ impl Storage<Vec<u8>> for BinFileStorage {
 	}
 
 	fn save(&mut self, data: Vec<u8>) -> Result<(), Self::Err> {
+		debug!("Saving file to: {:?}", &self.filepath);
 		let mut file = File::create(&self.filepath).map_err(EigenError::IOError)?;
 		file.write_all(&data).map_err(EigenError::IOError)
 	}


### PR DESCRIPTION
# Description

This PR integrates the threshold circuit in the library and enable threshold proofs generation through the cli.

## Related Issues

- Resolves #331 

## Changes 

- Create new commands to handle threshold proofs.
- Fetch attestations only if local file isn't found.
- Update file generation.
- Move `big_to_fe_rat` from test mod to actual util.
- Refactor main library to have specific functions to build the circuit structures that can be reused in multiple methods, `th_circuit_setup` and `et_circuit_setup`.