### PR TITLE
refactor(lib): client config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,8 @@ dependencies = [
  "ethers",
  "log",
  "reqwest",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/eigentrust-cli/Cargo.toml
+++ b/eigentrust-cli/Cargo.toml
@@ -10,6 +10,8 @@ env_logger = "0.10.0"
 ethers = "2.0.8"
 log = "0.4.19"
 reqwest = "0.11.18"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tokio = "1.18"
 
 # Path dependencies

--- a/eigentrust-cli/src/cli.rs
+++ b/eigentrust-cli/src/cli.rs
@@ -650,7 +650,7 @@ pub fn handle_update(data: UpdateData) -> Result<(), EigenError> {
 	let filepath = get_file_path("config", FileType::Json)?;
 	let mut json_storage = JSONFileStorage::<CliConfig>::new(filepath);
 
-	json_storage.save(config.clone())
+	json_storage.save(config)
 }
 
 /// Tries to load attestations from local storage. If no attestations are found,

--- a/eigentrust-cli/src/fs.rs
+++ b/eigentrust-cli/src/fs.rs
@@ -2,12 +2,12 @@
 //!
 //! This module provides functionalities for filesystem actions.
 
+use crate::CliConfig;
 use dotenv::{dotenv, var};
 use eigentrust::{
 	circuit::Circuit,
 	error::EigenError,
 	storage::{BinFileStorage, JSONFileStorage, Storage},
-	ClientConfig,
 };
 use log::warn;
 use std::{env::current_dir, path::PathBuf};
@@ -115,9 +115,9 @@ pub fn get_file_path(file_name: &str, file_type: FileType) -> Result<PathBuf, Ei
 }
 
 /// Loads the configuration file.
-pub fn load_config() -> Result<ClientConfig, EigenError> {
+pub fn load_config() -> Result<CliConfig, EigenError> {
 	let filepath = get_file_path(CONFIG_FILE, FileType::Json)?;
-	JSONFileStorage::<ClientConfig>::new(filepath).load()
+	JSONFileStorage::<CliConfig>::new(filepath).load()
 }
 
 #[cfg(test)]

--- a/eigentrust-cli/src/main.rs
+++ b/eigentrust-cli/src/main.rs
@@ -31,7 +31,7 @@ mod fs;
 use clap::Parser;
 use cli::*;
 use dotenv::dotenv;
-use eigentrust::{error::EigenError, ClientConfig};
+use eigentrust::error::EigenError;
 use env_logger::{init_from_env, Env};
 use fs::load_config;
 use log::info;
@@ -40,24 +40,23 @@ use log::info;
 async fn main() -> Result<(), EigenError> {
 	dotenv().ok();
 	init_from_env(Env::default().filter_or("LOG_LEVEL", "info"));
-	let mut config: ClientConfig = load_config()?;
 
 	match Cli::parse().mode {
-		Mode::Attest(attest_data) => handle_attest(config, attest_data).await?,
-		Mode::Attestations => handle_attestations(config).await?,
-		Mode::Bandada(bandada_data) => handle_bandada(&config, bandada_data).await?,
-		Mode::Deploy => handle_deploy(config).await?,
-		Mode::ETProof => handle_et_proof(config).await?,
+		Mode::Attest(attest_data) => handle_attest(attest_data).await?,
+		Mode::Attestations => handle_attestations().await?,
+		Mode::Bandada(bandada_data) => handle_bandada(bandada_data).await?,
+		Mode::Deploy => handle_deploy().await?,
+		Mode::ETProof => handle_et_proof().await?,
 		Mode::ETProvingKey => handle_et_pk()?,
-		Mode::ETVerify => handle_et_verify(config).await?,
-		Mode::KZGParams(data) => handle_params(data)?,
-		Mode::LocalScores => handle_scores(config, AttestationsOrigin::Local).await?,
-		Mode::Scores => handle_scores(config, AttestationsOrigin::Fetch).await?,
-		Mode::Show => info!("Client config:\n{:#?}", config),
-		Mode::ThProof(data) => handle_th_proof(config, data).await?,
-		Mode::ThProvingKey => handle_th_pk(config).await?,
-		Mode::ThVerify => handle_th_verify(config).await?,
-		Mode::Update(update_data) => handle_update(&mut config, update_data)?,
+		Mode::ETVerify => handle_et_verify().await?,
+		Mode::KZGParams(kzg_params_data) => handle_params(kzg_params_data)?,
+		Mode::LocalScores => handle_scores(AttestationsOrigin::Local).await?,
+		Mode::Scores => handle_scores(AttestationsOrigin::Fetch).await?,
+		Mode::Show => info!("Client config:\n{:#?}", load_config()?),
+		Mode::ThProof(th_proof_data) => handle_th_proof(th_proof_data).await?,
+		Mode::ThProvingKey => handle_th_pk().await?,
+		Mode::ThVerify => handle_th_verify().await?,
+		Mode::Update(update_data) => handle_update(update_data)?,
 	};
 
 	Ok(())

--- a/eigentrust/src/eth.rs
+++ b/eigentrust/src/eth.rs
@@ -96,25 +96,29 @@ pub fn scalar_from_address(address: &Address) -> Result<Scalar, EigenError> {
 
 #[cfg(test)]
 mod tests {
-	use crate::{eth::*, Client, ClientConfig, SecpScalar};
-	use ethers::utils::{hex, Anvil};
+	use crate::{eth::*, Client, SecpScalar};
+	use ethers::{
+		types::H160,
+		utils::{hex, Anvil},
+	};
+	use std::str::FromStr;
 
 	const TEST_MNEMONIC: &'static str =
 		"test test test test test test test test test test test junk";
+	const TEST_AS_ADDRESS: &'static str = "0x5fbdb2315678afecb367f032d93f642f64180aa3";
+	const TEST_CHAIN_ID: u32 = 31337;
 
 	#[tokio::test]
 	async fn test_deploy_as() {
 		let anvil = Anvil::new().spawn();
-		let config = ClientConfig {
-			as_address: "0x5fbdb2315678afecb367f032d93f642f64180aa3".to_string(),
-			band_id: "38922764296632428858395574229367".to_string(),
-			band_th: "500".to_string(),
-			band_url: "http://localhost:3000".to_string(),
-			chain_id: "31337".to_string(),
-			domain: "0x0000000000000000000000000000000000000000".to_string(),
-			node_url: anvil.endpoint().to_string(),
-		};
-		let client = Client::new(config, TEST_MNEMONIC.to_string());
+		let node_url = anvil.endpoint().to_string();
+		let client = Client::new(
+			TEST_MNEMONIC.to_string(),
+			TEST_CHAIN_ID,
+			Address::from_str(TEST_AS_ADDRESS).unwrap().to_fixed_bytes(),
+			H160::zero().to_fixed_bytes(),
+			node_url,
+		);
 
 		// Deploy
 		let res = deploy_as(client.signer).await;


### PR DESCRIPTION
# Description

This PR removes the `ClientConfig` struct from the main library. The main purpose of it was to simplify settings storage, but this is an application and not a library concern. It also had data that the library itself wasn't using.

It has been moved to the CLI crate and the `Client` constructor has been updated to receive the necessary data to spin up, and store in memory whatever is needed for the library methods.


## Related Issues

- Resolves #369 

## Changes 

- Update library tests
- Remove `ClientConfig` from the library and implement `CliConfig` in the CLI.
- Update cli handle function arguments